### PR TITLE
feat: augment metrics with cid and cid+path counters

### DIFF
--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -61,7 +61,11 @@ export async function gatewayGet(request, env, ctx) {
     // Update cache metrics in background
     const responseTime = Date.now() - startTs
 
-    ctx.waitUntil(updateSummaryCacheMetrics(request, env, res, responseTime))
+    ctx.waitUntil(
+      updateSummaryCacheMetrics(request, env, res, responseTime, {
+        pathname,
+      })
+    )
     return res
   }
 
@@ -103,7 +107,9 @@ export async function gatewayGet(request, env, ctx) {
         )
 
         await Promise.all([
-          storeWinnerGwResponse(request, env, winnerGwResponse),
+          storeWinnerGwResponse(request, env, winnerGwResponse, {
+            pathname,
+          }),
           settleGatewayRequests(),
           // Cache request URL in Cloudflare CDN if smaller than CF_CACHE_MAX_OBJECT_SIZE
           contentLengthMb <= CF_CACHE_MAX_OBJECT_SIZE &&
@@ -132,7 +138,8 @@ export async function gatewayGet(request, env, ctx) {
             updateGatewayMetrics(request, env, r.value, false)
           )
         )
-        wasRateLimited && updateGatewayRedirectCounter(request, env)
+        // Update redirect counter
+        wasRateLimited && (await updateGatewayRedirectCounter(request, env))
       })()
     )
 
@@ -168,12 +175,19 @@ export async function gatewayGet(request, env, ctx) {
  *
  * @param {Request} request
  * @param {Env} env
- * @param {GatewayResponse} winnerGwResponse
+ * @param {GatewayResponse} gwResponse
+ * @param {Object} [options]
+ * @param {string} [options.pathname]
  */
-async function storeWinnerGwResponse(request, env, winnerGwResponse) {
+async function storeWinnerGwResponse(
+  request,
+  env,
+  gwResponse,
+  { pathname } = {}
+) {
   await Promise.all([
-    updateGatewayMetrics(request, env, winnerGwResponse, true),
-    updateSummaryWinnerMetrics(request, env, winnerGwResponse),
+    updateGatewayMetrics(request, env, gwResponse, true),
+    updateSummaryWinnerMetrics(request, env, { gwResponse, pathname }),
   ])
 }
 
@@ -257,8 +271,16 @@ function getHeaders(request) {
  * @param {import('./env').Env} env
  * @param {Response} response
  * @param {number} responseTime
+ * @param {Object} [options]
+ * @param {string} [options.pathname]
  */
-async function updateSummaryCacheMetrics(request, env, response, responseTime) {
+async function updateSummaryCacheMetrics(
+  request,
+  env,
+  response,
+  responseTime,
+  { pathname } = {}
+) {
   // Get durable object for summary
   const id = env.summaryMetricsDurable.idFromName(SUMMARY_METRICS_ID)
   const stub = env.summaryMetricsDurable.get(id)
@@ -267,6 +289,7 @@ async function updateSummaryCacheMetrics(request, env, response, responseTime) {
   const contentLengthStats = {
     contentLength: Number(response.headers.get('content-length')),
     responseTime,
+    pathname,
   }
 
   await stub.fetch(
@@ -306,17 +329,24 @@ async function getGatewayRateLimitState(request, env) {
 /**
  * @param {Request} request
  * @param {import('./env').Env} env
- * @param {GatewayResponse} gwResponse
+ * @param {Object} options
+ * @param {GatewayResponse} [options.gwResponse]
+ * @param {string} [options.pathname]
  */
-async function updateSummaryWinnerMetrics(request, env, gwResponse) {
+async function updateSummaryWinnerMetrics(
+  request,
+  env,
+  { gwResponse, pathname }
+) {
   // Get durable object for gateway
   const id = env.summaryMetricsDurable.idFromName(SUMMARY_METRICS_ID)
   const stub = env.summaryMetricsDurable.get(id)
 
   /** @type {import('./durable-objects/summary-metrics').FetchStats} */
   const fetchStats = {
-    responseTime: gwResponse.responseTime,
-    contentLength: Number(gwResponse.response.headers.get('content-length')),
+    contentLength: Number(gwResponse?.response.headers.get('content-length')),
+    responseTime: gwResponse?.responseTime,
+    pathname,
   }
 
   await stub.fetch(getDurableRequestUrl(request, 'metrics/winner', fetchStats))

--- a/packages/edge-gateway/src/metrics.js
+++ b/packages/edge-gateway/src/metrics.js
@@ -267,6 +267,18 @@ export async function metricsGet(request, env, ctx) {
     `# HELP nftgateway_redirect_total Total redirects to gateway.`,
     `# TYPE nftgateway_redirect_total counter`,
     `nftgateway_redirect_total{env="${env.ENV}"} ${metricsCollected.gatewayRedirectCount}`,
+    `# HELP nftgateway_responses_by_query_type_total total of responses by query status. Either CID or CID+PATH.`,
+    `# TYPE nftgateway_responses_by_query_type_total counter`,
+    Object.keys(metricsCollected.summaryMetrics.totalResponsesByQueryType)
+      .map(
+        (type) =>
+          `nftgateway_responses_by_query_type_total{env="${
+            env.ENV
+          }",type="${type}"} ${
+            metricsCollected.summaryMetrics.totalResponsesByQueryType[type] || 0
+          }`
+      )
+      .join('\n'),
   ].join('\n')
 
   res = new Response(metrics, {

--- a/packages/edge-gateway/test/metrics.spec.js
+++ b/packages/edge-gateway/test/metrics.spec.js
@@ -43,6 +43,14 @@ test('Gets Metrics content when empty state', async (t) => {
     ),
     true
   )
+  t.is(
+    metricsResponse.includes('nftgateway_winner_response_time_seconds_total'),
+    true
+  )
+  t.is(
+    metricsResponse.includes('nftgateway_winner_response_time_seconds_total'),
+    true
+  )
   gateways.forEach((gw) => {
     t.is(
       metricsResponse.includes(`_requests_total{gateway="${gw}",env="test"} 0`),
@@ -121,6 +129,38 @@ test('Gets Metrics content', async (t) => {
       true
     )
   })
+})
+
+test('gets Metrics from query type', async (t) => {
+  const { mf } = t.context
+
+  const p = await Promise.all([
+    mf.dispatchFetch(
+      'http://bafybeih74zqc6kamjpruyra4e4pblnwdpickrvk4hvturisbtveghflovq.ipfs.localhost:8787'
+    ),
+    mf.dispatchFetch(
+      'https://bafybeih74zqc6kamjpruyra4e4pblnwdpickrvk4hvturisbtveghflovq.ipfs.localhost:8787/path'
+    ),
+  ])
+
+  // Wait for waitUntil
+  await Promise.all(p.map((p) => p.waitUntil()))
+
+  const response = await mf.dispatchFetch('http://localhost:8787/metrics')
+  const metricsResponse = await response.text()
+
+  t.is(
+    metricsResponse.includes(
+      `nftgateway_responses_by_query_type_total{env="test",type="CID"} 1`
+    ),
+    true
+  )
+  t.is(
+    metricsResponse.includes(
+      `nftgateway_responses_by_query_type_total{env="test",type="CID+PATH"} 1`
+    ),
+    true
+  )
 })
 
 test('Gets Metrics from faster gateway', async (t) => {


### PR DESCRIPTION
As part of nftstorage/nftstorage.link#18 this PR augments metrics with query type counter. Prometheus metrics look as follows:

```

# HELP nftgateway_responses_by_query_type_total total of responses by query status. Either CID or CID+PATH.
# TYPE nftgateway_responses_by_query_type_total counter
nftgateway_responses_by_query_type_total{env="test",type="CID"} 1
nftgateway_responses_by_query_type_total{env="test",type="CID+PATH"} 1
```

Moved from https://github.com/nftstorage/nft.storage/pull/1429