### PR TITLE
feat: gateway tracking metrics ipld codec and multihash function

### DIFF
--- a/packages/edge-gateway/package.json
+++ b/packages/edge-gateway/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "itty-router": "^2.4.5",
+    "multicodec": "^3.2.1",
     "multiformats": "^9.6.4",
     "nanoid": "^3.1.30",
     "p-any": "^4.0.0",

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -61,7 +61,9 @@ export async function gatewayGet(request, env, ctx) {
     // Update cache metrics in background
     const responseTime = Date.now() - startTs
 
-    ctx.waitUntil(updateSummaryCacheMetrics(request, env, res, responseTime))
+    ctx.waitUntil(
+      updateSummaryCacheMetrics(request, env, res, responseTime, cid)
+    )
     return res
   }
 
@@ -103,7 +105,7 @@ export async function gatewayGet(request, env, ctx) {
         )
 
         await Promise.all([
-          storeWinnerGwResponse(request, env, winnerGwResponse),
+          storeWinnerGwResponse(request, env, winnerGwResponse, cid),
           settleGatewayRequests(),
           // Cache request URL in Cloudflare CDN if smaller than CF_CACHE_MAX_OBJECT_SIZE
           contentLengthMb <= CF_CACHE_MAX_OBJECT_SIZE &&
@@ -169,11 +171,12 @@ export async function gatewayGet(request, env, ctx) {
  * @param {Request} request
  * @param {Env} env
  * @param {GatewayResponse} winnerGwResponse
+ * @param {string} cid
  */
-async function storeWinnerGwResponse(request, env, winnerGwResponse) {
+async function storeWinnerGwResponse(request, env, winnerGwResponse, cid) {
   await Promise.all([
     updateGatewayMetrics(request, env, winnerGwResponse, true),
-    updateSummaryWinnerMetrics(request, env, winnerGwResponse),
+    updateSummaryWinnerMetrics(request, env, cid, winnerGwResponse),
   ])
 }
 
@@ -257,14 +260,22 @@ function getHeaders(request) {
  * @param {import('./env').Env} env
  * @param {Response} response
  * @param {number} responseTime
+ * @param {string} cid
  */
-async function updateSummaryCacheMetrics(request, env, response, responseTime) {
+async function updateSummaryCacheMetrics(
+  request,
+  env,
+  response,
+  responseTime,
+  cid
+) {
   // Get durable object for summary
   const id = env.summaryMetricsDurable.idFromName(SUMMARY_METRICS_ID)
   const stub = env.summaryMetricsDurable.get(id)
 
   /** @type {import('./durable-objects/summary-metrics').FetchStats} */
   const contentLengthStats = {
+    cid,
     contentLength: Number(response.headers.get('content-length')),
     responseTime,
   }
@@ -306,15 +317,17 @@ async function getGatewayRateLimitState(request, env) {
 /**
  * @param {Request} request
  * @param {import('./env').Env} env
+ * @param {string} cid
  * @param {GatewayResponse} gwResponse
  */
-async function updateSummaryWinnerMetrics(request, env, gwResponse) {
+async function updateSummaryWinnerMetrics(request, env, cid, gwResponse) {
   // Get durable object for gateway
   const id = env.summaryMetricsDurable.idFromName(SUMMARY_METRICS_ID)
   const stub = env.summaryMetricsDurable.get(id)
 
   /** @type {import('./durable-objects/summary-metrics').FetchStats} */
   const fetchStats = {
+    cid,
     responseTime: gwResponse.responseTime,
     contentLength: Number(gwResponse.response.headers.get('content-length')),
   }

--- a/packages/edge-gateway/src/metrics.js
+++ b/packages/edge-gateway/src/metrics.js
@@ -267,6 +267,35 @@ export async function metricsGet(request, env, ctx) {
     `# HELP nftgateway_redirect_total Total redirects to gateway.`,
     `# TYPE nftgateway_redirect_total counter`,
     `nftgateway_redirect_total{env="${env.ENV}"} ${metricsCollected.gatewayRedirectCount}`,
+    `# HELP nftgateway_responses_by_ipld_codec_total total of responses by ipld codec.`,
+    `# TYPE nftgateway_responses_by_ipld_codec_total counter`,
+    Object.keys(metricsCollected.summaryMetrics.totalResponsesByIpldCodec)
+      .map(
+        (codec) =>
+          `nftgateway_responses_by_ipld_codec_total{env="${
+            env.ENV
+          }",codec="${codec}"} ${
+            metricsCollected.summaryMetrics.totalResponsesByIpldCodec[codec] ||
+            0
+          }`
+      )
+      .join('\n'),
+    `# HELP nftgateway_responses_by_multihash_function_total total of responses by multihash function.`,
+    `# TYPE nftgateway_responses_by_multihash_function_total counter`,
+    Object.keys(
+      metricsCollected.summaryMetrics.totalResponsesByMultihashFunction
+    )
+      .map(
+        (fn) =>
+          `nftgateway_responses_by_multihash_function_total{env="${
+            env.ENV
+          }",function="${fn}"} ${
+            metricsCollected.summaryMetrics.totalResponsesByMultihashFunction[
+              fn
+            ] || 0
+          }`
+      )
+      .join('\n'),
   ].join('\n')
 
   res = new Response(metrics, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ importers:
       ipfs-utils: ^9.0.4
       itty-router: ^2.4.5
       miniflare: ^2.2.0
+      multicodec: ^3.2.1
       multiformats: ^9.6.4
       nanoid: ^3.1.30
       npm-run-all: ^4.1.5
@@ -47,6 +48,7 @@ importers:
       uint8arrays: ^3.0.0
     dependencies:
       itty-router: 2.6.1
+      multicodec: 3.2.1
       multiformats: 9.6.4
       nanoid: 3.3.2
       p-any: 4.0.0
@@ -8229,6 +8231,17 @@ packages:
       - supports-color
     dev: true
 
+  /multicodec/3.2.1:
+    resolution:
+      {
+        integrity: sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==,
+      }
+    deprecated: This module has been superseded by the multiformats module
+    dependencies:
+      uint8arrays: 3.0.0
+      varint: 6.0.0
+    dev: false
+
   /multiformats/9.6.4:
     resolution:
       {
@@ -11008,7 +11021,6 @@ packages:
       {
         integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==,
       }
-    dev: true
 
   /vary/1.1.2:
     resolution: { integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw= }


### PR DESCRIPTION
As part of nftstorage/nftstorage.link#18 this PR augments metrics with ipld codec and multihash function type counter. Prometheus metrics look as follows:

```
# HELP nftgateway_responses_by_ipld_codec_total total of responses by ipld codec.
# TYPE nftgateway_responses_by_ipld_codec_total counter
nftgateway_responses_by_ipld_codec_total{env="test",codec="raw"} 1
# HELP nftgateway_responses_by_multihash_function_total total of responses by multihash function.
# TYPE nftgateway_responses_by_multihash_function_total counter
nftgateway_responses_by_multihash_function_total{env="test",function="sha2-256"} 1
```

Moved from https://github.com/nftstorage/nft.storage/pull/1442