### PR TITLE
fix: sentry source maps for worker.mjs

### DIFF
--- a/packages/edge-gateway/package.json
+++ b/packages/edge-gateway/package.json
@@ -4,7 +4,7 @@
   "description": "IPFS edge gateway for nft.storage",
   "private": true,
   "type": "module",
-  "module": "./dist/worker.mjs",
+  "main": "./dist/worker.mjs",
   "scripts": {
     "build": "node scripts/cli.js build",
     "dev": "miniflare --watch --debug",

--- a/packages/edge-gateway/scripts/cli.js
+++ b/packages/edge-gateway/scripts/cli.js
@@ -56,6 +56,7 @@ async function buildCmd(opts) {
     outfile: path.join(__dirname, '..', 'dist', 'worker.mjs'),
     legalComments: 'external',
     define: {
+      SENTRY_RELEASE: JSON.stringify(sentryRelease),
       VERSION: JSON.stringify(pkg.version),
       COMMITHASH: JSON.stringify(git.long(__dirname)),
       BRANCH: JSON.stringify(git.branch(__dirname)),
@@ -81,7 +82,7 @@ async function buildCmd(opts) {
       ignoreMissing: true,
     })
     await cli.releases.uploadSourceMaps(sentryRelease, {
-      include: ['./dist'],
+      include: [path.join(__dirname, '..', 'dist')],
       ext: ['map', 'mjs'],
     })
     await cli.releases.finalize(sentryRelease)

--- a/packages/edge-gateway/src/env.js
+++ b/packages/edge-gateway/src/env.js
@@ -6,7 +6,8 @@ import { Logging } from './logs.js'
  * @typedef {Object} EnvInput
  * @property {string} IPFS_GATEWAYS
  * @property {string} GATEWAY_HOSTNAME
- * @property {string} VERSION
+ * @property {string} SENTRY_RELEASE
+ * @property {string} VERSION SENTRY_RELEASE
  * @property {string} COMMITHASH
  * @property {string} BRANCH
  * @property {string} DEBUG
@@ -85,7 +86,7 @@ function getSentry(request, env, ctx) {
         filename: frame.filename.substring(1),
       }),
     },
-    release: env.VERSION,
+    release: env.SENTRY_RELEASE,
     pkg,
   })
 }

--- a/packages/edge-gateway/src/env.js
+++ b/packages/edge-gateway/src/env.js
@@ -43,7 +43,7 @@ import { Logging } from './logs.js'
  * @param {import('.').Ctx} ctx
  */
 export function envAll(request, env, ctx) {
-  env.sentry = getSentry(request, env)
+  env.sentry = getSentry(request, env, ctx)
   env.ipfsGateways = JSON.parse(env.IPFS_GATEWAYS)
   env.gatewayMetricsDurable = env.GATEWAYMETRICS
   env.summaryMetricsDurable = env.SUMMARYMETRICS
@@ -63,8 +63,9 @@ export function envAll(request, env, ctx) {
  *
  * @param {Request} request
  * @param {Env} env
+ * @param {import('.').Ctx} ctx
  */
-function getSentry(request, env) {
+function getSentry(request, env, ctx) {
   if (!env.SENTRY_DSN) {
     return
   }
@@ -72,6 +73,7 @@ function getSentry(request, env) {
   return new Toucan({
     request,
     dsn: env.SENTRY_DSN,
+    context: ctx,
     allowedHeaders: ['user-agent'],
     allowedSearchParams: /(.*)/,
     debug: false,


### PR DESCRIPTION
We currently don't have sourcemaps in sentry. These are the only differences I could find from the working source maps in web3storage project per changes in https://github.com/web3-storage/web3.storage/pull/1033