### PR TITLE
fix: build env

### DIFF
--- a/packages/edge-gateway/scripts/cli.js
+++ b/packages/edge-gateway/scripts/cli.js
@@ -24,7 +24,7 @@ const prog = sade('gateway')
 prog
   .command('build')
   .describe('Build the worker.')
-  .option('--env', 'Environment', 'dev')
+  .option('--env', 'Environment', process.env.ENV)
   .action(buildCmd)
   .command('ipfs')
   .describe('Run ipfs node')


### PR DESCRIPTION
The build env is specified in workflows, but not used ENV var to build like https://github.com/web3-storage/web3.storage/blob/main/packages/api/scripts/cli.js#L20