### PR TITLE
feat: add gateway forbidden content types

### DIFF
--- a/packages/edge-gateway/src/constants.js
+++ b/packages/edge-gateway/src/constants.js
@@ -9,3 +9,4 @@ export const HTTP_STATUS_RATE_LIMITED = 429
 export const HTTP_STATUS_SUCCESS = 200
 export const REQUEST_PREVENTED_RATE_LIMIT_CODE = 'RATE_LIMIT'
 export const TIMEOUT_CODE = 'TIMEOUT'
+export const FORBIDDEN_CONTENT_TYPES = ['application/octet-stream']

--- a/packages/edge-gateway/src/errors.js
+++ b/packages/edge-gateway/src/errors.js
@@ -26,7 +26,7 @@ export class ForbiddenContentError extends Error {
     this.contentType = 'text/html'
   }
 }
-ForbiddenContentError.CODE = 'ERROR_INVALID_URL'
+ForbiddenContentError.CODE = 'ERROR_FORBIDDEN_CONTENT'
 
 export class TimeoutError extends Error {
   /**

--- a/packages/edge-gateway/src/errors.js
+++ b/packages/edge-gateway/src/errors.js
@@ -13,6 +13,21 @@ export class InvalidUrlError extends Error {
 }
 InvalidUrlError.CODE = 'ERROR_INVALID_URL'
 
+export class ForbiddenContentError extends Error {
+  /**
+   * @param {string} message
+   */
+  constructor(message = 'Forbidden content') {
+    const status = 403
+    super(createErrorHtmlContent(status, message))
+    this.name = 'ForbiddenContentError'
+    this.status = status
+    this.code = ForbiddenContentError.CODE
+    this.contentType = 'text/html'
+  }
+}
+ForbiddenContentError.CODE = 'ERROR_INVALID_URL'
+
 export class TimeoutError extends Error {
   /**
    * @param {string} message

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -105,6 +105,15 @@ export async function gatewayGet(request, env, ctx) {
       ])
     }
 
+    const winnerContentType =
+      winnerGwResponse.response.headers.get('content-type')
+    // Block content types
+    if (FORBIDDEN_CONTENT_TYPES.includes(winnerContentType)) {
+      throw new ForbiddenContentError(
+        `Forbidden content type: ${winnerContentType}`
+      )
+    }
+
     ctx.waitUntil(
       (async () => {
         const contentLengthMb = Number(
@@ -119,19 +128,6 @@ export async function gatewayGet(request, env, ctx) {
         ])
       })()
     )
-
-    // Block content types
-    if (
-      FORBIDDEN_CONTENT_TYPES.includes(
-        winnerGwResponse.response.headers.get('content-type')
-      )
-    ) {
-      throw new ForbiddenContentError(
-        `Forbidden content type: ${winnerGwResponse.response.headers.get(
-          'content-type'
-        )}`
-      )
-    }
 
     // forward winner gateway response
     return winnerGwResponse.response


### PR DESCRIPTION
This PR adds forbidden content types to avoid abuse as we were seeing ~28% of traffic with bin files from last 12 hours https://dash.cloudflare.com/fffa4b4363a7e5250af8357087263b3a/nftstorage.link/analytics/traffic?content-type=bin

This can also be problematic for gateway being blocked by other parties and we should investigate other types to block.

CF may still just put `bin` on other kind of types if does not know about. Anyway, we should just block `octet-stream` to start. This should likely evolve into a wrangler secret / Admin feature.