### PR TITLE
fix: integrate edge gateway in api until workers bindings available

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@supabase/postgrest-js": "^0.37.2",
+    "edge-gateway": "^1.5.5",
     "itty-router": "^2.4.5",
     "multiformats": "^9.6.4",
     "nanoid": "^3.1.30",
@@ -33,7 +34,6 @@
     "ava": "^3.15.0",
     "browser-env": "^3.3.0",
     "dotenv": "^16.0.0",
-    "edge-gateway": "^1.5.5",
     "esbuild": "^0.14.2",
     "execa": "^5.1.1",
     "git-rev-sync": "^3.0.1",

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -56,6 +56,13 @@ export function envAll(request, env, ctx) {
 
   env.log = new Logging(request, env, ctx)
   env.log.time('request')
+
+  /**
+   * Add gateway environment
+   * will be removed once workers bindings are in place.
+   */
+  // @ts-ignore types not complete - Special inputs for Env
+  env.ipfsGateways = JSON.parse(env.IPFS_GATEWAYS)
 }
 
 /**

--- a/packages/api/test/perma-cache-post.spec.js
+++ b/packages/api/test/perma-cache-post.spec.js
@@ -194,7 +194,6 @@ const validateSuccessfulPut = async (t, url, body, responseTxt) => {
   const { normalizedUrl, sourceUrl } = getParsedUrl(url)
   t.is(body.url, sourceUrl)
   t.truthy(body.insertedAt)
-  t.falsy(body.deletedAt)
   t.truthy(body.size)
 
   // Validate DB

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -22,12 +22,16 @@ main = "worker.mjs"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 zone_id = "c7795a0adce7609a95d62fec04705aff"    # nftstorage.link zone
 route = "api.nftstorage.link/*"
+kv_namespaces = [
+  { binding = "DENYLIST", id = "785cf627e913468ca5319523ae929def" }
+]
 
 [env.production.vars]
 DATABASE_URL = "https://nft-link-prod.herokuapp.com"
 DEBUG = "false"
 ENV = "production"
 GATEWAY_DOMAIN = "nftstorage.link"
+IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.nftstorage.link\", \"https://nft-storage.mypinata.cloud/\"]"
 
 [[env.production.r2_buckets]]
 bucket_name = "super-hot"
@@ -39,12 +43,16 @@ binding = "SUPERHOT"
 account_id = "fffa4b4363a7e5250af8357087263b3a" # Protocol Labs CF account
 zone_id = "c7795a0adce7609a95d62fec04705aff"    # nftstorage.link zone
 route = "api-staging.nftstorage.link/*"
+kv_namespaces = [
+  { binding = "DENYLIST", id = "f4eb0eca32e14e28b643604a82e00cb3" }
+]
 
 [env.staging.vars]
 DATABASE_URL = "https://nft-link-staging.herokuapp.com"
 DEBUG = "true"
 ENV = "staging"
 GATEWAY_DOMAIN = "nftstorage.link"
+IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.nftstorage.link\", \"https://nft-storage.mypinata.cloud/\"]"
 
 [[env.staging.r2_buckets]]
 bucket_name = "super-hot-staging"
@@ -58,6 +66,7 @@ workers_dev = true
 DEBUG = "true"
 ENV = "test"
 GATEWAY_DOMAIN = "localhost:9081"
+IPFS_GATEWAYS = "[\"http://127.0.0.1:9081\"]"
 
 # Dev!
 [env.vsantos]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,7 @@ importers:
       uint8arrays: ^3.0.0
     dependencies:
       '@supabase/postgrest-js': 0.37.2
+      edge-gateway: link:../edge-gateway
       itty-router: 2.6.1
       multiformats: 9.6.4
       nanoid: 3.3.3
@@ -57,7 +58,6 @@ importers:
       ava: 3.15.0
       browser-env: 3.3.0
       dotenv: 16.0.0
-      edge-gateway: link:../edge-gateway
       esbuild: 0.14.38
       execa: 5.1.1
       git-rev-sync: 3.0.2


### PR DESCRIPTION
We have two workers now, one for the gateway and one for the API, as they should just be independent services.

As part of `/perma-cache/put/`, a request must be performed to the gateway in order to get the response to be stored in R2. However, two workers cannot HTTP with each other if they are within same CF zone (nftstorage.link). 

There is a brand new solution for this https://blog.cloudflare.com/service-bindings-ga/ which as of 10th May is now open. However, there is an incompatibility between Service Bindings and R2. When we do a fetch from a Service Binding and put its response in R2 it errors (created a reproduction case and shared with CF a few weeks ago https://github.com/vasco-santos/workers-bindings-r2 but waiting on getting it fixed).

As a way to be able to test this in staging, this PR has a small refactor on gateway code to export relevant function that API can just import and use (of course with its own ENV Vars properly setup...).

This can also be seen as a first step to extract common code of the gateway to a lib. But I avoided much complexity now and It essentially decouples all Durable Objects related code and adds callbacks for it. We will still need to discuss better how to decouple remaining pieces for getting an independent lib extracted.