### PR TITLE
feat: add heartbeat to cron jobs

### DIFF
--- a/.github/workflows/cron-denylist.yml
+++ b/.github/workflows/cron-denylist.yml
@@ -31,3 +31,7 @@ jobs:
         env:
           CF_API_TOKEN: ${{ secrets.CF_GATEWAY_TOKEN }}
         run: node packages/edge-gateway/scripts/cli.js denylist sync --env ${{ matrix.env }}
+
+      - name: Heartbeat
+        if: ${{ success() }}
+        run: ./packages/edge-gateway/scripts/cli.js heartbeat --token ${{ secrets.OPSGENIE_KEY }} --name cron-nftstoragelink-denylist

--- a/packages/edge-gateway/scripts/cli.js
+++ b/packages/edge-gateway/scripts/cli.js
@@ -12,6 +12,7 @@ import pWaitFor from 'p-wait-for'
 import { create } from 'ipfs-http-client'
 import globSource from 'ipfs-utils/src/files/glob-source.js'
 import { denylistSyncCmd, denylistAddCmd } from './denylist.js'
+import { heartbeatCmd } from './heartbeat.js'
 
 const IPFS_API_URL = 'http://127.0.0.1:9089'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -31,6 +32,10 @@ prog
   .option('--start', 'Start docker container', false)
   .option('--stop', 'Stop and clean all dockers artifacts', false)
   .action(ipfsCmd)
+  .command('heartbeat', 'Ping opsgenie heartbeat')
+  .option('--token', 'Opsgenie Token')
+  .option('--name', 'Heartbeat Name')
+  .action(heartbeatCmd)
   .command('denylist sync')
   .describe('Sync the gateway deny list with various sources.')
   .option('--env', 'Wrangler environment to use.', 'dev')

--- a/packages/edge-gateway/scripts/heartbeat.js
+++ b/packages/edge-gateway/scripts/heartbeat.js
@@ -1,0 +1,14 @@
+import { fetch } from '@web-std/fetch'
+
+export async function heartbeatCmd(opts) {
+  try {
+    await fetch(`https://api.opsgenie.com/v2/heartbeats/${opts.name}/ping`, {
+      headers: {
+        Authorization: `GenieKey ${opts.token}`,
+      },
+    })
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
Adds heartbeat to cron jobs to track when cron jobs fail and trigger alerts to opsgenie

TODO:
- [x] add OPSGENIE_KEY secret
- [ ] setup opsgenie with expected heartbeats (only possible after merge)