### PR TITLE
feat: status API

### DIFF
--- a/packages/status-api/README.md
+++ b/packages/status-api/README.md
@@ -1,0 +1,3 @@
+# nftstorage.link status API
+
+Outputs a simple JSON file to the `dist` directory with current status.

--- a/packages/status-api/README.md
+++ b/packages/status-api/README.md
@@ -1,3 +1,40 @@
 # nftstorage.link status API
 
 Outputs a simple JSON file to the `dist` directory with current status.
+
+## Updating current status
+
+Login to DigitalOcean, find the app and set the `STATUS` environment variable to "ok" (for all OK) or anything else for not ok.
+
+## Infra
+
+Hosted in DigitalOcean with the following app spec:
+
+```yaml
+envs:
+  - key: STATUS
+    scope: RUN_AND_BUILD_TIME
+    value: ok
+name: nftstorage-link-status-api
+region: lon
+static_sites:
+  - build_command: npm run build
+    environment_slug: node-js
+    github:
+      branch: main
+      deploy_on_push: true
+      repo: nftstorage/nftstorage.link
+    name: nftstorage-link-status-api
+    routes:
+      - path: /
+    source_dir: packages/status-api
+    index_document: index.json
+    cors:
+      allow_origins:
+        - exact: '*'
+      allow_methods:
+        - GET
+        - OPTIONS
+```
+
+Note: `index_document` and `cors` config are the two additions to the default. See https://docs.digitalocean.com/products/app-platform/references/app-specification-reference/.

--- a/packages/status-api/build.js
+++ b/packages/status-api/build.js
@@ -1,0 +1,8 @@
+import fs from 'fs'
+import path from 'path'
+
+const status = process.env.STATUS
+if (!status) throw new Error('missing environment variable: STATUS')
+
+fs.mkdirSync('dist', { recursive: true })
+fs.writeFileSync(path.join('dist', 'index.json'), JSON.stringify({ status }))

--- a/packages/status-api/package-lock.json
+++ b/packages/status-api/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "status-api",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "status-api",
+      "version": "0.0.0",
+      "license": "Apache-2.0 OR MIT"
+    }
+  }
+}

--- a/packages/status-api/package.json
+++ b/packages/status-api/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "status-api",
+  "version": "0.0.0",
+  "description": "IPFS Edge Gateway Status API",
+  "main": "build.js",
+  "type": "module",
+  "scripts": {
+    "build": "node build.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Alan Shaw",
+  "license": "Apache-2.0 OR MIT"
+}


### PR DESCRIPTION
Here's a static site we can deploy in DigitalOcean for our status API. I chose to deploy it somewhere different from Cloudflare since that is where we host the gateway.

It's just a static site so it should scale nicely.

It's driven by an environment variable `STATUS` - when it changes, DO will rebuild and deploy the site with the new value.

It's currently deployed here: https://nftstorage-link-status-api-v899x.ondigitalocean.app/

TODO:

* [x] Buy a domain...

refs https://github.com/nftstorage/nftstorage.link/pull/49