### PR TITLE
fix: prometheus header rename

### DIFF
--- a/packages/edge-gateway/src/metrics.js
+++ b/packages/edge-gateway/src/metrics.js
@@ -233,8 +233,8 @@ export async function metricsGet(request, env, ctx) {
       (gw) =>
         `nftgateway_winner_requests_total{gateway="${gw}",env="${env.ENV}"} ${metricsCollected.ipfsGateways[gw].totalWinnerRequests}`
     ),
-    `# HELP nftgateway_requests_per_time_total total of successful requests per response time bucket`,
-    `# TYPE nftgateway_requests_per_time_total histogram`,
+    `# HELP nftgateway_successful_requests_per_time_total total of successful requests per response time bucket`,
+    `# TYPE nftgateway_successful_requests_per_time_total histogram`,
     ...responseTimeHistogram.map((t) => {
       return env.ipfsGateways
         .map(


### PR DESCRIPTION
We renamed the metric name in https://github.com/nftstorage/nftstorage.link/pull/80 but not the header 😞 