### PR TITLE
chore: add new cid to denylist

### DIFF
--- a/packages/edge-gateway/denylist.json
+++ b/packages/edge-gateway/denylist.json
@@ -13,5 +13,8 @@
   },
   {
     "anchor": "aa0f67e571898373070228efb814f97b2e47243b290e5191883f016ef34e0990"
+  },
+  {
+    "anchor": "7d3c2a0a48c08ba342e10e6cf60f16959db0ab91a45ea6baf1a40396e53681f4"
   }
 ]


### PR DESCRIPTION
We got a report of a new deceptive CID QmV6zSvdPAbUjtA3bvqRehHh63yq1MS5idk8UacCmz8pin that redirects to a deceptive site