### PR TITLE
fix: perma cache delete multiple common urls

### DIFF
--- a/packages/api/src/perma-cache/delete.js
+++ b/packages/api/src/perma-cache/delete.js
@@ -18,11 +18,15 @@ export async function permaCacheDelete(request, env) {
   const normalizedUrl = getNormalizedUrl(sourceUrl, env)
   const r2Key = normalizedUrl.toString()
 
-  const res = await env.db.deletePermaCache(
+  const { deletedAt, hasMoreReferences } = await env.db.deletePermaCache(
     request.auth.user.id,
     normalizedUrl.toString()
   )
-  await env.SUPERHOT.delete(r2Key)
 
-  return new JSONResponse(Boolean(res))
+  // Delete from R2 if no more references
+  if (!hasMoreReferences) {
+    await env.SUPERHOT.delete(r2Key)
+  }
+
+  return new JSONResponse(Boolean(deletedAt))
 }

--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -126,19 +126,18 @@ export class DBClient {
    * @param {string} url
    */
   async deletePermaCache(userId, url) {
-    const { data } = await this._client.rpc('delete_perma_cache', {
-      data: {
-        user_id: userId,
-        normalized_url: url,
-      },
+    const { data, error } = await this._client.rpc('delete_perma_cache', {
+      query_user_id: userId,
+      query_normalized_url: url,
     })
 
-    if (!data || !data.length) {
-      return undefined
+    if (error) {
+      throw new DBError(error)
     }
 
     return {
-      id: data[0].id,
+      deletedAt: data.deleted_at,
+      hasMoreReferences: data.has_more_references,
     }
   }
 

--- a/packages/api/test/perma-cache-delete.spec.js
+++ b/packages/api/test/perma-cache-delete.spec.js
@@ -1,10 +1,10 @@
-import test from 'ava'
+import ava from 'ava'
 
 import { getMiniflare } from './scripts/utils.js'
 import { createTestUser, dbClient } from './scripts/helpers.js'
 import { getParsedUrl } from './utils.js'
 
-test.beforeEach(async (t) => {
+ava.beforeEach(async (t) => {
   const user = await createTestUser({
     grantRequiredTags: true,
   })
@@ -16,13 +16,15 @@ test.beforeEach(async (t) => {
   }
 })
 
+const test = ava.serial
+
 // DELETE /perma-cache
 test('Can delete perma cache content', async (t) => {
   const { mf, user } = t.context
   const bindings = await mf.getBindings()
   const r2Bucket = bindings.SUPERHOT
   const url =
-    'http://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:9081/'
+    'http://bafkreibxkbyybantsznyvlq2bhf24u4gew7pj6erjgduqp4mvqv54qjng4.ipfs.localhost:9081/'
 
   // Post
   const responsePost = await mf.dispatchFetch(getPermaCachePutUrl(url), {
@@ -71,7 +73,7 @@ test('Can delete perma cache content with source url', async (t) => {
   const bindings = await mf.getBindings()
   const r2Bucket = bindings.SUPERHOT
   const url =
-    'http://localhost:9081/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq/'
+    'http://localhost:9081/ipfs/bafkreibxkbyybantsznyvlq2bhf24u4gew7pj6erjgduqp4mvqv54qjng4/'
 
   const { normalizedUrl } = getParsedUrl(url)
   // Post
@@ -134,7 +136,7 @@ test('Can add content that was previously deleted', async (t) => {
   const bindings = await mf.getBindings()
   const r2Bucket = bindings.SUPERHOT
   const url =
-    'http://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:9081'
+    'http://bafkreibxkbyybantsznyvlq2bhf24u4gew7pj6erjgduqp4mvqv54qjng4.ipfs.localhost:9081'
 
   // Post 1
   const responsePost1 = await mf.dispatchFetch(getPermaCachePutUrl(url), {
@@ -179,6 +181,45 @@ test('Can add content that was previously deleted', async (t) => {
   t.is(data.filter((event) => event.type === 'Put').length, 2)
   // Exists DELETE event
   t.truthy(data.find((event) => event.type === 'Delete'))
+})
+
+test('should not delete from R2 bucket if url was perma cached by other user', async (t) => {
+  const { mf, user } = t.context
+  const bindings = await mf.getBindings()
+  const r2Bucket = bindings.SUPERHOT
+  const url =
+    'http://bafkreihbjbbccwxn7hzv5hun5pxuswide7q3lhjvfbvmd7r3kf2sodybgi.ipfs.localhost:9081'
+
+  // Post 1
+  const responsePost1 = await mf.dispatchFetch(getPermaCachePutUrl(url), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${user.token}` },
+  })
+  t.is(responsePost1.status, 200)
+
+  // Post 2
+  const user2 = await createTestUser({
+    grantRequiredTags: true,
+  })
+  const responsePost2 = await mf.dispatchFetch(getPermaCachePutUrl(url), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${user2.token}` },
+  })
+  t.is(responsePost2.status, 200)
+
+  // Delete
+  const responseDelete = await mf.dispatchFetch(getPermaCachePutUrl(url), {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${user.token}` },
+  })
+  t.is(responseDelete.status, 200)
+  const success = await responseDelete.json()
+  t.truthy(success)
+
+  // Verify R2
+  const { normalizedUrl } = getParsedUrl(url)
+  const r2ResponseExistent = await r2Bucket.get(normalizedUrl)
+  t.truthy(r2ResponseExistent)
 })
 
 const getPermaCachePutUrl = (url) =>


### PR DESCRIPTION
This PR fixes HTTP `DELETE /perma-cache/:url` that should not remove from perma cache when there are still references to the URL

Tests had a few changes:
- need to be sequential to have all the previous ones to remove from perma cache bucket
- new CIDs to avoid collisions with other tests, as data will already be in DB