### PR TITLE
refactor: perma-cache naming convention

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -9,15 +9,15 @@ CREATE TYPE user_tag_type AS ENUM
   'StorageLimitBytes'
 );
 
--- Perma cache transaction type.
+-- Perma-cache transaction type.
 CREATE TYPE perma_cache_event_type AS ENUM (
-    -- A PUT event on perma cache.
+    -- A PUT event on perma-cache.
     'Put',
-    -- A DELETE event on perma cache.
+    -- A DELETE event on perma-cache.
     'Delete'
     );
 
--- A nftstorage.link perma cache entry.
+-- A nftstorage.link perma-cache entry.
 CREATE TABLE IF NOT EXISTS public.perma_cache
 (
     id             BIGSERIAL PRIMARY KEY,
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS public.perma_cache
 
 CREATE INDEX IF NOT EXISTS perma_cache_user_id_idx ON perma_cache (user_id);
 
--- A nftstorage.link perma cache event.
+-- A nftstorage.link perma-cache event.
 CREATE TABLE IF NOT EXISTS public.perma_cache_event
 (
     id             BIGSERIAL PRIMARY KEY,

--- a/packages/api/src/metrics.js
+++ b/packages/api/src/metrics.js
@@ -27,16 +27,16 @@ export async function metricsGet(request, env, ctx) {
     ])
 
   const metrics = [
-    `# HELP nftlinkapi_permacache_urls_total Total perma cached urls.`,
+    `# HELP nftlinkapi_permacache_urls_total Total perma-cached urls.`,
     `# TYPE nftlinkapi_permacache_urls_total counter`,
     `nftlinkapi_permacache_urls_total ${urlsTotal}`,
-    `# HELP nftlinkapi_permacache_users_total Total number of users with perma cached urls.`,
+    `# HELP nftlinkapi_permacache_users_total Total number of users with perma-cached urls.`,
     `# TYPE nftlinkapi_permacache_users_total counter`,
     `nftlinkapi_permacache_users_total ${usersTotal}`,
-    `# HELP nftlinkapi_permacache_size_total Total perma cached size.`,
+    `# HELP nftlinkapi_permacache_size_total Total perma-cached size.`,
     `# TYPE nftlinkapi_permacache_size_total counter`,
     `nftlinkapi_permacache_size_total ${sizeTotal}`,
-    `# HELP nftlinkapi_permacache_events_total Total perma cache events.`,
+    `# HELP nftlinkapi_permacache_events_total Total perma-cache events.`,
     `# TYPE nftlinkapi_permacache_events_total counter`,
     `nftlinkapi_permacache_events_total{type="Put"} ${putEventsTotal}`,
     `nftlinkapi_permacache_events_total{type="Delete"} ${deleteEventsTotal}`,

--- a/packages/api/src/perma-cache/post.js
+++ b/packages/api/src/perma-cache/post.js
@@ -39,11 +39,11 @@ export async function permaCachePost(request, env, ctx) {
   const r2Key = normalizedUrl.toString()
   const userId = request.auth.user.id
 
-  // Checking if existent does not protect us of concurrent perma cache
+  // Checking if existent does not protect us of concurrent perma-cache
   // but avoids downloading content to fail later.
   const existing = await env.db.getPermaCache(userId, normalizedUrl.toString())
   if (existing) {
-    throw new HTTPError('The provided URL was already perma cached', 400)
+    throw new HTTPError('The provided URL was already perma-cached', 400)
   }
 
   // Fetch Response from provided URL
@@ -62,7 +62,7 @@ export async function permaCachePost(request, env, ctx) {
     httpMetadata: response.headers,
   })
 
-  // Will fail on concurrent perma cache of pair (userId, url)
+  // Will fail on concurrent perma-cache of pair (userId, url)
   const data = await env.db.createPermaCache({
     userId,
     sourceUrl: sourceUrl.toString(),

--- a/packages/api/src/utils/db-client.js
+++ b/packages/api/src/utils/db-client.js
@@ -50,14 +50,14 @@ export class DBClient {
     }
 
     if (!data) {
-      throw new Error('Perma cache not created.')
+      throw new Error('Perma-cache not created.')
     }
 
     return data
   }
 
   /**
-   * Get perma cache Entry
+   * Get perma-cache Entry
    *
    * @param {number} userId
    * @param {string} url
@@ -83,7 +83,7 @@ export class DBClient {
   }
 
   /**
-   * List perma cache
+   * List perma-cache
    *
    * @param {number} userId
    * @param {Object} opts
@@ -120,7 +120,7 @@ export class DBClient {
   }
 
   /**
-   * List perma cache
+   * List perma-cache
    *
    * @param {number} userId
    * @param {string} url
@@ -142,7 +142,7 @@ export class DBClient {
   }
 
   /**
-   * Get perma cache storage in bytes.
+   * Get perma-cache storage in bytes.
    *
    * @param {number} userId
    * @returns {Promise<number>}

--- a/packages/api/test/perma-cache-delete.spec.js
+++ b/packages/api/test/perma-cache-delete.spec.js
@@ -117,7 +117,7 @@ test('Can delete perma cache content with source url', async (t) => {
   t.falsy(r2ResponseNonExistent)
 })
 
-test('Fails to delete unexistent perma cache content', async (t) => {
+test('Fails to delete unexistent perma-cache content', async (t) => {
   const { mf, user } = t.context
   const url =
     'http://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:9081'
@@ -183,7 +183,7 @@ test('Can add content that was previously deleted', async (t) => {
   t.truthy(data.find((event) => event.type === 'Delete'))
 })
 
-test('should not delete from R2 bucket if url was perma cached by other user', async (t) => {
+test('should not delete from R2 bucket if url was perma-cached by other user', async (t) => {
   const { mf, user } = t.context
   const bindings = await mf.getBindings()
   const r2Bucket = bindings.SUPERHOT

--- a/packages/api/test/perma-cache-get.spec.js
+++ b/packages/api/test/perma-cache-get.spec.js
@@ -18,7 +18,7 @@ test.beforeEach(async (t) => {
 })
 
 // PUT /perma-cache
-test('Gets empty list when there were no perma cached objects previously added', async (t) => {
+test('Gets empty list when there were no perma-cached objects previously added', async (t) => {
   const { mf, user } = t.context
   const response = await mf.dispatchFetch(
     'https://localhost:8788/perma-cache',
@@ -33,7 +33,7 @@ test('Gets empty list when there were no perma cached objects previously added',
   t.is(entries.length, 0)
 })
 
-test('Gets list when there were perma cached objects previously added', async (t) => {
+test('Gets list when there were perma-cached objects previously added', async (t) => {
   const { mf, user } = t.context
 
   // Perma cache URLs
@@ -74,7 +74,7 @@ test('Gets list when there were perma cached objects previously added', async (t
 test('Can paginate list', async (t) => {
   const { mf, user } = t.context
 
-  // Perma cache URLs
+  // Perma-cache URLs
   const urls = [
     'http://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:9081?download=true',
     'http://localhost:9081/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq',

--- a/packages/api/test/perma-cache-post.spec.js
+++ b/packages/api/test/perma-cache-post.spec.js
@@ -50,7 +50,7 @@ test('Fails when non nftstorage.link url is provided', async (t) => {
   )
 })
 
-test('Puts to perma cache IPFS path valid url without directory path', async (t) => {
+test('Puts to perma-cache IPFS path valid url without directory path', async (t) => {
   const { mf, user } = t.context
   const url =
     'http://localhost:9081/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'
@@ -65,7 +65,7 @@ test('Puts to perma cache IPFS path valid url without directory path', async (t)
   await validateSuccessfulPut(t, url, body, gatewayTxtResponse)
 })
 
-test('Puts to perma cache IPFS path valid url with directory path', async (t) => {
+test('Puts to perma-cache IPFS path valid url with directory path', async (t) => {
   const { mf, user } = t.context
 
   const url =
@@ -81,7 +81,7 @@ test('Puts to perma cache IPFS path valid url with directory path', async (t) =>
   await validateSuccessfulPut(t, url, body, gatewayTxtResponse)
 })
 
-test('Puts to perma cache IPFS subdomain valid url without directory path', async (t) => {
+test('Puts to perma-cache IPFS subdomain valid url without directory path', async (t) => {
   const { mf, user } = t.context
   const url =
     'http://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:9081'
@@ -96,7 +96,7 @@ test('Puts to perma cache IPFS subdomain valid url without directory path', asyn
   await validateSuccessfulPut(t, url, body, gatewayTxtResponse)
 })
 
-test('Puts to perma cache IPFS subdomain valid url with directory path', async (t) => {
+test('Puts to perma-cache IPFS subdomain valid url with directory path', async (t) => {
   const { mf, user } = t.context
   const url =
     'http://bafybeih74zqc6kamjpruyra4e4pblnwdpickrvk4hvturisbtveghflovq.ipfs.localhost:9081/path'
@@ -111,7 +111,7 @@ test('Puts to perma cache IPFS subdomain valid url with directory path', async (
   await validateSuccessfulPut(t, url, body, gatewayTxtResponse)
 })
 
-test('Puts to perma cache IPFS subdomain valid url with query parameters', async (t) => {
+test('Puts to perma-cache IPFS subdomain valid url with query parameters', async (t) => {
   const { mf, user } = t.context
   const url =
     'http://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:9081?download=true'
@@ -126,7 +126,7 @@ test('Puts to perma cache IPFS subdomain valid url with query parameters', async
   await validateSuccessfulPut(t, url, body, gatewayTxtResponse)
 })
 
-test('Fails to put to perma cache ipfs path with invalid cid', async (t) => {
+test('Fails to put to perma-cache ipfs path with invalid cid', async (t) => {
   const { mf, user } = t.context
 
   const response = await mf.dispatchFetch(
@@ -144,7 +144,7 @@ test('Fails to put to perma cache ipfs path with invalid cid', async (t) => {
   )
 })
 
-test('Fails when it was already perma cached', async (t) => {
+test('Fails when it was already perma-cached', async (t) => {
   const { mf, user } = t.context
   const url =
     'http://localhost:9081/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'
@@ -161,10 +161,10 @@ test('Fails when it was already perma cached', async (t) => {
   })
   t.is(response2.status, 400)
   const body = await response2.json()
-  t.is(body, 'The provided URL was already perma cached')
+  t.is(body, 'The provided URL was already perma-cached')
 })
 
-test('Fails on concurrent perma cache attempt of same URL', async (t) => {
+test('Fails on concurrent perma-cache attempt of same URL', async (t) => {
   const { mf, user } = t.context
   const urls = [
     'http://localhost:9081/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq',

--- a/packages/api/test/perma-cache-status.spec.js
+++ b/packages/api/test/perma-cache-status.spec.js
@@ -15,7 +15,7 @@ test.beforeEach(async (t) => {
   }
 })
 
-test('Get perma cache status from user', async (t) => {
+test('Get perma-cache status from user', async (t) => {
   const { mf, user } = t.context
   const statusResponseEmpty = await mf.dispatchFetch(
     'https://localhost:8788/perma-cache/status',

--- a/packages/website/public/schema.yml
+++ b/packages/website/public/schema.yml
@@ -139,7 +139,7 @@ components:
         url:
           type: string
           example: https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.nftstorage.link/
-          description: 'URL as provided for perma cache.'
+          description: 'URL as provided for perma-cache.'
         size:
           type: number
           example: 600


### PR DESCRIPTION
We decided to name `perma-cache` everywhere to be consistent, removing some occurrences from `perma cache`