### PR TITLE
feat: api and gateway version endpoint

### DIFF
--- a/packages/api/src/index.js
+++ b/packages/api/src/index.js
@@ -10,6 +10,7 @@ import {
   permaCacheDelete,
 } from './perma-cache/index.js'
 import { metricsGet } from './metrics.js'
+import { versionGet } from './version.js'
 import { addCorsHeaders, withCorsHeaders } from './cors.js'
 import { errorHandler } from './error-handler.js'
 import { envAll } from './env.js'
@@ -24,6 +25,7 @@ const auth = {
 router
   .all('*', envAll)
   .get('/metrics', withCorsHeaders(metricsGet))
+  .get('/version', withCorsHeaders(versionGet))
   .get('/perma-cache', auth['🔒'](permaCacheListGet))
   .post('/perma-cache/:url', auth['🔒'](permaCachePost))
   .get('/perma-cache/status', auth['🔒'](permaCacheStatusGet))

--- a/packages/api/src/version.js
+++ b/packages/api/src/version.js
@@ -1,7 +1,7 @@
 import { JSONResponse } from './utils/json-response.js'
 
 /**
- * Get web3.storage API version information.
+ * Get API version information.
  *
  * @param {Request} request
  * @param {import('./env').Env} env

--- a/packages/api/src/version.js
+++ b/packages/api/src/version.js
@@ -1,0 +1,15 @@
+import { JSONResponse } from './utils/json-response.js'
+
+/**
+ * Get web3.storage API version information.
+ *
+ * @param {Request} request
+ * @param {import('./env').Env} env
+ */
+export async function versionGet(request, env) {
+  return new JSONResponse({
+    version: env.VERSION,
+    commit: env.COMMITHASH,
+    branch: env.BRANCH,
+  })
+}

--- a/packages/api/test/version.spec.js
+++ b/packages/api/test/version.spec.js
@@ -1,0 +1,30 @@
+import test from 'ava'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import git from 'git-rev-sync'
+
+import { getMiniflare } from './scripts/utils.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+)
+
+test.before((t) => {
+  // Create a new Miniflare environment for each test
+  t.context = {
+    mf: getMiniflare(),
+  }
+})
+
+test('Gets Version', async (t) => {
+  const { mf } = t.context
+
+  const response = await mf.dispatchFetch('http://localhost:8787/version')
+  const { version, commit, branch } = await response.json()
+
+  t.is(version, pkg.version)
+  t.is(commit, git.long(__dirname))
+  t.is(branch, git.branch(__dirname))
+})

--- a/packages/edge-gateway/src/index.js
+++ b/packages/edge-gateway/src/index.js
@@ -6,6 +6,7 @@ import { ipfsGet } from './ipfs.js'
 import { ipnsGet } from './ipns.js'
 import { gatewayGet } from './gateway.js'
 import { metricsGet } from './metrics.js'
+import { versionGet } from './version.js'
 
 // Export Durable Object namespace from the root module.
 export { GatewayMetrics1 } from './durable-objects/gateway-metrics.js'
@@ -22,6 +23,7 @@ const router = Router()
 router
   .all('*', envAll)
   .get('/metrics', withCorsHeaders(metricsGet))
+  .get('/version', withCorsHeaders(versionGet))
   .get('/ipfs/:cid', withCorsHeaders(ipfsGet))
   .get('/ipfs/:cid/*', withCorsHeaders(ipfsGet))
   .head('/ipfs/:cid', withCorsHeaders(ipfsGet))

--- a/packages/edge-gateway/src/utils/json-response.js
+++ b/packages/edge-gateway/src/utils/json-response.js
@@ -1,0 +1,12 @@
+/* eslint-env serviceworker */
+export class JSONResponse extends Response {
+  /**
+   * @param {any} body
+   * @param {ResponseInit} [init]
+   */
+  constructor(body, init = {}) {
+    init.headers = init.headers || {}
+    init.headers['Content-Type'] = 'application/json;charset=UTF-8'
+    super(JSON.stringify(body), init)
+  }
+}

--- a/packages/edge-gateway/src/version.js
+++ b/packages/edge-gateway/src/version.js
@@ -1,0 +1,15 @@
+import { JSONResponse } from './utils/json-response.js'
+
+/**
+ * Get web3.storage API version information.
+ *
+ * @param {Request} request
+ * @param {import('./env').Env} env
+ */
+export async function versionGet(request, env) {
+  return new JSONResponse({
+    version: env.VERSION,
+    commit: env.COMMITHASH,
+    branch: env.BRANCH,
+  })
+}

--- a/packages/edge-gateway/src/version.js
+++ b/packages/edge-gateway/src/version.js
@@ -1,7 +1,7 @@
 import { JSONResponse } from './utils/json-response.js'
 
 /**
- * Get web3.storage API version information.
+ * Get Gateway API version information.
  *
  * @param {Request} request
  * @param {import('./env').Env} env

--- a/packages/edge-gateway/test/version.spec.js
+++ b/packages/edge-gateway/test/version.spec.js
@@ -1,0 +1,30 @@
+import test from 'ava'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import git from 'git-rev-sync'
+
+import { getMiniflare } from './utils.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+)
+
+test.before((t) => {
+  // Create a new Miniflare environment for each test
+  t.context = {
+    mf: getMiniflare(),
+  }
+})
+
+test('Gets Version', async (t) => {
+  const { mf } = t.context
+
+  const response = await mf.dispatchFetch('http://localhost:8787/version')
+  const { version, commit, branch } = await response.json()
+
+  t.is(version, pkg.version)
+  t.is(commit, git.long(__dirname))
+  t.is(branch, git.branch(__dirname))
+})


### PR DESCRIPTION
Add `GET /version` to nftstorage.link API and gateway

Closes #44 