### PR TITLE
fix: workflow website deploy command

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -129,7 +129,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     name: Release
     runs-on: ubuntu-latest
-    needs: check
+    needs: build
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
         id: tag-release
@@ -152,6 +152,6 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: pnpm install
         if: ${{ steps.tag-release.outputs.releases_created }}
-      - name: Website - Deploy
-        if: ${{ steps.tag-release.outputs.releases_created }}
-        run: ./packages/tools/cli.js deploy-website --email ${{ secrets.CF_EMAIL }} --key ${{secrets.CF_KEY}} --zone ${{ secrets.CF_ZONE }} --account ${{secrets.CF_ACCOUNT}}
+      - run: npx dnslink-cloudflare --record _dnslink --domain nftstorage.link --link /ipfs/${{ needs.build.outputs.cid }}
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_GATEWAY_TOKEN }}


### PR DESCRIPTION
We don't need the command run, but to update _dnslink record