### PR TITLE
chore: use m1 compat ipfs docker

### DIFF
--- a/packages/api/docker/docker-ipfs.yml
+++ b/packages/api/docker/docker-ipfs.yml
@@ -3,7 +3,7 @@ version: '3.6'
 services:
   ipfs1:
     container_name: ipfs1
-    image: ipfs/go-ipfs:v0.12.0
+    image: ipfs/go-ipfs:v0.10.0 # update this when go-ipfs M1 macs https://github.com/ipfs/go-ipfs/issues/8645
     ports:
       - '9089:5001' # ipfs api - expose if needed/wanted
       - '9081:8080' # ipfs gateway - expose if needed/wanted

--- a/packages/api/scripts/cli.js
+++ b/packages/api/scripts/cli.js
@@ -37,7 +37,7 @@ prog
   .option('--init', 'Init docker container', false)
   .option('--start', 'Start docker container', false)
   .option('--stop', 'Stop docker container', false)
-  .option('--project', 'Project name', 'nftstorage.link-api')
+  .option('--project', 'Project name', 'nftstoragelink-api')
   .option('--clean', 'Clean all dockers artifacts', false)
   .action(dbCmd)
   .command('db-sql')

--- a/packages/edge-gateway/docker/docker-compose.yml
+++ b/packages/edge-gateway/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.6'
 services:
   ipfs0:
     container_name: ipfs0
-    image: ipfs/go-ipfs:v0.12.0
+    image: ipfs/go-ipfs:v0.10.0 # update this when go-ipfs M1 macs https://github.com/ipfs/go-ipfs/issues/8645
     ports:
       - '9089:5001' # ipfs api - expose if needed/wanted
       - '9081:8080' # ipfs gateway - expose if needed/wanted


### PR DESCRIPTION
Until go-ipfs 0.13 is shipped, we can't run tests with version in place in M1