### PR TITLE
feat: use worker bindings interacting from api to gateway

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@supabase/postgrest-js": "^0.37.2",
-    "edge-gateway": "^1.5.5",
     "itty-router": "^2.4.5",
     "multiformats": "^9.6.4",
     "nanoid": "^3.1.30",
@@ -35,6 +34,7 @@
     "ava": "^3.15.0",
     "browser-env": "^3.3.0",
     "dotenv": "^16.0.0",
+    "edge-gateway": "^1.5.5",
     "esbuild": "^0.14.38",
     "execa": "^5.1.1",
     "git-rev-sync": "^3.0.1",

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -18,6 +18,7 @@ import { DBClient } from './utils/db-client.js'
  * @property {KVNamespace} PERMACACHE
  * @property {KVNamespace} PERMACACHE_HISTORY
  * @property {R2Bucket} SUPERHOT
+ * @property {CFService} GATEWAY
  *
  * @typedef {Object} EnvTransformed
  * @property {string} VERSION
@@ -56,13 +57,6 @@ export function envAll(request, env, ctx) {
 
   env.log = new Logging(request, env, ctx)
   env.log.time('request')
-
-  /**
-   * Add gateway environment
-   * will be removed once workers bindings are in place.
-   */
-  // @ts-ignore types not complete - Special inputs for Env
-  env.ipfsGateways = JSON.parse(env.IPFS_GATEWAYS)
 }
 
 /**
@@ -99,6 +93,8 @@ function getSentry(request, env, ctx) {
 
 /**
  * From: https://github.com/cloudflare/workers-types
+ *
+ * @typedef {{ fetch: fetch }} CFService
  *
  * @typedef {Object} KVNamespacePutOptions
  * @property {any} [metadata]

--- a/packages/api/test/scripts/gateway.js
+++ b/packages/api/test/scripts/gateway.js
@@ -22,7 +22,6 @@ export default {
  * @param {URL} url
  */
 function getCidFromSubdomainUrl(url) {
-  // Replace "ipfs-staging" by "ipfs" if needed
   const splitHost = url.hostname.split('.ipfs.')
 
   if (!splitHost.length) {

--- a/packages/api/test/scripts/gateway.js
+++ b/packages/api/test/scripts/gateway.js
@@ -1,0 +1,33 @@
+export default {
+  async fetch(request) {
+    const reqUrl = new URL(request.url)
+    // We need to perform requests as path based per localhost subdomain resolution
+    const subdomainCid = getCidFromSubdomainUrl(reqUrl)
+    if (subdomainCid) {
+      return await fetch(
+        new URL(
+          `/ipfs/${subdomainCid}${reqUrl.pathname}`,
+          'http://127.0.0.1:9081'
+        )
+      )
+    }
+
+    return await fetch(request.url.replace('localhost', '127.0.0.1'))
+  },
+}
+
+/**
+ * Parse subdomain URL and return cid
+ *
+ * @param {URL} url
+ */
+function getCidFromSubdomainUrl(url) {
+  // Replace "ipfs-staging" by "ipfs" if needed
+  const splitHost = url.hostname.split('.ipfs.')
+
+  if (!splitHost.length) {
+    return undefined
+  }
+
+  return splitHost[0]
+}

--- a/packages/api/test/scripts/utils.js
+++ b/packages/api/test/scripts/utils.js
@@ -25,8 +25,18 @@ export function getMiniflare() {
     buildCommand: undefined,
     wranglerConfigEnv: 'test',
     modules: true,
+    mounts: {
+      gateway: {
+        scriptPath: './test/scripts/gateway.js',
+        modules: true,
+      },
+    },
+    serviceBindings: {
+      GATEWAY: 'gateway',
+    },
     bindings: {
       ...globals,
+      // Cloudflare R2
       SUPERHOT: createR2Bucket(),
     },
   })

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -26,7 +26,7 @@ GATEWAY_DOMAIN = "nftstorage.link"
 bucket_name = "super-hot"
 binding = "SUPERHOT"
 
-[[env.production.unsafe.bindings]]
+[[env.production.bindings]]
 name = "GATEWAY"
 type = "service"
 service = "gateway-nft-storage-production"
@@ -52,7 +52,7 @@ GATEWAY_DOMAIN = "nftstorage.link"
 bucket_name = "super-hot-staging"
 binding = "SUPERHOT"
 
-[[env.staging.unsafe.bindings]]
+[[env.staging.bindings]]
 name = "GATEWAY"
 type = "service"
 service = "gateway-nft-storage-staging"

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -21,11 +21,16 @@ NFT_STORAGE_API = "https://api.nft.storage"
 DEBUG = "false"
 ENV = "production"
 GATEWAY_DOMAIN = "nftstorage.link"
-IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.nftstorage.link\", \"https://nft-storage.mypinata.cloud/\"]"
 
 [[env.production.r2_buckets]]
 bucket_name = "super-hot"
 binding = "SUPERHOT"
+
+[[env.production.unsafe.bindings]]
+name = "GATEWAY"
+type = "service"
+service = "gateway-nft-storage-production"
+environment = "production"
 
 # Staging!
 [env.staging]
@@ -42,11 +47,16 @@ NFT_STORAGE_API = "https://api-staging.nft.storage"
 DEBUG = "true"
 ENV = "staging"
 GATEWAY_DOMAIN = "nftstorage.link"
-IPFS_GATEWAYS = "[\"https://ipfs.io\", \"https://cf.nftstorage.link\", \"https://nft-storage.mypinata.cloud/\"]"
 
 [[env.staging.r2_buckets]]
 bucket_name = "super-hot-staging"
 binding = "SUPERHOT"
+
+[[env.staging.unsafe.bindings]]
+name = "GATEWAY"
+type = "service"
+service = "gateway-nft-storage-staging"
+environment = "production"
 
 # Test!
 [env.test]
@@ -56,7 +66,6 @@ workers_dev = true
 DEBUG = "true"
 ENV = "test"
 GATEWAY_DOMAIN = "localhost:9081"
-IPFS_GATEWAYS = "[\"http://127.0.0.1:9081\"]"
 
 # Dev!
 [env.vsantos]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,6 @@ importers:
       uint8arrays: ^3.0.0
     dependencies:
       '@supabase/postgrest-js': 0.37.2
-      edge-gateway: link:../edge-gateway
       itty-router: 2.6.1
       multiformats: 9.6.4
       nanoid: 3.3.3
@@ -61,6 +60,7 @@ importers:
       ava: 3.15.0
       browser-env: 3.3.0
       dotenv: 16.0.0
+      edge-gateway: link:../edge-gateway
       esbuild: 0.14.38
       execa: 5.1.1
       git-rev-sync: 3.0.2


### PR DESCRIPTION
This PR adds:
- worker bindings from API to Gateway

Implementation details:
- miniflare support for testing bindings is still quite limited, we cannot spin up the other worker build, and it does not seem to support ESM either...
- bindings from API to Gateway tests use custom script that does the fetch to the local daemon converting subdomain resolution to path resolution. This is because we can't resolve localhost subdomains locally unless we add them to `/etc/hosts`, which is not cool, given we can't use tools like https://github.com/feross/hostile without sudo for pre and post tests... There was the option of relying on services like https://readme.localtest.me/ but don't really want to use external services in CI

Needs:
- [x] wrangler 2

Initial binding part of https://github.com/nftstorage/nftstorage.link/issues/101 to move to worker bindings setup