### PR TITLE
docs: fix status route

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -104,7 +104,7 @@ $ curl -X GET -H 'Authorization: Bearer YOUR_API_KEY' https://api.nftstorage.lin
 > Get perma-cache account status.
 
 ```console
-$ curl -X GET -H 'Authorization: Bearer YOUR_API_KEY' https://api.nftstorage.link/perma-cache -s | jq
+$ curl -X GET -H 'Authorization: Bearer YOUR_API_KEY' https://api.nftstorage.link/perma-cache/status -s | jq
 {
   "usedStorage": "8036759278"
 }


### PR DESCRIPTION
Ups, missing `/status` in readme