### PR TITLE
feat: full range header support

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@supabase/postgrest-js": "^0.37.2",
+    "http-range-parse": "^1.0.0",
     "itty-router": "^2.4.5",
     "multiformats": "^9.6.4",
     "nanoid": "^3.1.30",

--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -126,9 +126,16 @@ function getSentry(request, env, ctx) {
  * @property {Headers} [httpMetadata]
  * @property {Record<string, string>} [customMetadata]
  *
+ * @typedef {{ offset: number, length?: number } | { offset?: number, length: number } | { suffix: number }} R2Range
+ *
+ * @typedef {Object} R2GetOptions
+ * @property {R2Range} [range]
+ *
  * @typedef {Object} R2Object
  * @property {Date} uploaded
  * @property {number} size
+ * @property {string} httpEtag
+ * @property {(headers: Headers) => void} writeHttpMetadata
  * @property {Headers} [httpMetadata]
  * @property {Record<string, string>} [customMetadata]
  *
@@ -144,7 +151,7 @@ function getSentry(request, env, ctx) {
  *
  * @typedef {Object} R2Bucket
  * @property {(key: string) => Promise<R2Object | null>} head
- * @property {(key: string) => Promise<R2ObjectBody | null>} get
+ * @property {(key: string, options?: R2GetOptions) => Promise<Response & R2Object | null>} get
  * @property {(key: string, value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null, options?: R2PutOptions) => Promise<R2Object>} put
  * @property {(key: string) => Promise<void>} delete
  */

--- a/packages/api/src/errors.js
+++ b/packages/api/src/errors.js
@@ -45,6 +45,20 @@ export class TimeoutError extends Error {
 }
 TimeoutError.CODE = 'ERROR_TIMEOUT'
 
+export class InvalidRangeError extends Error {
+  /**
+   * @param {string} message
+   */
+  constructor(message = 'invalid Range') {
+    const status = 400
+    super(message)
+    this.name = 'InvalidRangeError'
+    this.status = status
+    this.code = InvalidRangeError.CODE
+  }
+}
+InvalidRangeError.CODE = 'ERROR_INVALID_RANGE'
+
 export class HTTPError extends Error {
   /**
    *

--- a/packages/api/test/perma-cache-get.spec.js
+++ b/packages/api/test/perma-cache-get.spec.js
@@ -43,6 +43,36 @@ test('Gets content from perma cache by URL', async (t) => {
   t.deepEqual(await responseGet.text(), gatewayTxtResponse)
 })
 
+test('Gets range content from perma cache by URL', async (t) => {
+  const { mf, user } = t.context
+
+  const url =
+    'http://localhost:9081/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'
+  const gatewayTxtResponse = 'Hello nft.storage! 😎'
+
+  // Post URL content to perma cache
+  const responsePost = await mf.dispatchFetch(getPermaCachePutUrl(url), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${user.token}` },
+  })
+  t.is(responsePost.status, 200)
+
+  // GET URL content from perma cache
+  const { normalizedUrl } = getParsedUrl(url)
+
+  const responseGet = await mf.dispatchFetch(
+    getPermaCachePutUrl(normalizedUrl),
+    {
+      method: 'GET',
+      headers: {
+        Range: 'bytes=0-2',
+      },
+    }
+  )
+  t.is(responseGet.status, 206)
+  t.deepEqual(await responseGet.text(), gatewayTxtResponse.slice(0, 2 + 1)) // range includes
+})
+
 test('Gets 404 response from perma cache by URL when url not perma cached', async (t) => {
   const { mf } = t.context
   const url =

--- a/packages/api/test/scripts/mocks/r2.js
+++ b/packages/api/test/scripts/mocks/r2.js
@@ -32,19 +32,25 @@ export function createR2Bucket() {
         size: data.length,
       })
     },
-    get: async (key) => {
+    get: async (key, options = {}) => {
       const value = bucket.get(key)
       if (!value) {
         return undefined
       }
 
-      const response = new Response(value.body, { status: 200 })
+      let body = value.body
+      if (options.range) {
+        body = value.body.slice(options.range.offset, options.range.length)
+      }
+
+      const response = new Response(body, { status: 200 })
 
       return Promise.resolve(
         Object.assign(response, {
           httpMetadata: value.httpMetadata || {},
           customMetadata: value.customMetadata || {},
           size: value.body.length,
+          writeHttpMetadata: () => {},
         })
       )
     },

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -159,9 +159,9 @@ export async function gatewayIpfs(request, env, ctx, options = {}) {
           winnerGwResponse.response.headers.get('content-length')
         )
 
-        // Cache request URL in Cloudflare CDN if smaller than CF_CACHE_MAX_OBJECT_SIZE
+        // Cache request in Cloudflare CDN if smaller than CF_CACHE_MAX_OBJECT_SIZE
         if (contentLengthMb <= CF_CACHE_MAX_OBJECT_SIZE) {
-          await cache.put(request.url, winnerGwResponse.response.clone())
+          await cache.put(request, winnerGwResponse.response.clone())
         }
       })()
     )
@@ -272,7 +272,11 @@ async function cdnResolution(request, env, cache) {
 
   try {
     const res = await pAny(
-      [cache.match(request.url), getFromPermaCache(request, env)],
+      [
+        cache.match(request), // Request from cache API
+        cache.match(request.url), // Request URL from cache API - To be deprecated
+        getFromPermaCache(request, env),
+      ],
       {
         filter: (res) => !!res,
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ importers:
       esbuild: ^0.14.38
       execa: ^5.1.1
       git-rev-sync: ^3.0.1
+      http-range-parse: ^1.0.0
       itty-router: ^2.4.5
       miniflare: ^2.5.0
       multiformats: ^9.6.4
@@ -50,6 +51,7 @@ importers:
       uint8arrays: ^3.0.0
     dependencies:
       '@supabase/postgrest-js': 0.37.2
+      http-range-parse: 1.0.0
       itty-router: 2.6.1
       multiformats: 9.6.4
       nanoid: 3.3.3
@@ -11199,6 +11201,13 @@ packages:
       statuses: 2.0.1
       toidentifier: 1.0.1
     dev: true
+
+  /http-range-parse/1.0.0:
+    resolution:
+      {
+        integrity: sha512-8xfObVjVGz3VGdiMbbsxoMhxgZrcLOagvzf5rcTfwU2OmmyWJib6Y9rtyjjIFFJ8J/UUEaik4U6AmvnC70YLiw==,
+      }
+    dev: false
 
   /http-signature/1.2.0:
     resolution: { integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE= }


### PR DESCRIPTION
This PR adds range header support to both content requested to Cache API, as well as from perma cache. The headers already go to the race as well, so race already does range

Needs:
- [x] https://github.com/nftstorage/nftstorage.link/pull/136
- [x] https://github.com/nftstorage/nftstorage.link/pull/140

Closes #77 