### PR TITLE
fix: add new user tag to type from nft.storage

### DIFF
--- a/packages/api/db/tables.sql
+++ b/packages/api/db/tables.sql
@@ -6,7 +6,8 @@ CREATE TYPE user_tag_type AS ENUM
   'HasAccountRestriction',
   'HasPsaAccess',
   'HasSuperHotAccess',
-  'StorageLimitBytes'
+  'StorageLimitBytes',
+  'HasDeleteRestriction'
 );
 
 -- Perma-cache transaction type.


### PR DESCRIPTION
This was added to nft.storage schema and needs to be ported here given FDW don't support types