### PR TITLE
feat: support base cid encodings

### DIFF
--- a/packages/edge-gateway/package.json
+++ b/packages/edge-gateway/package.json
@@ -19,6 +19,7 @@
     "mock:cf-ipfs.com": "smoke -p 9083 test/mocks/cf-ipfs.com"
   },
   "dependencies": {
+    "ipfs-core-utils": "^0.15.0",
     "itty-router": "^2.4.5",
     "multiformats": "^9.6.4",
     "nanoid": "^3.1.30",

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -99,7 +99,7 @@ export async function gatewayGet(request, env, ctx) {
 export async function gatewayIpfs(request, env, ctx, options = {}) {
   const startTs = Date.now()
   const reqUrl = new URL(request.url)
-  const cid = getCidFromSubdomainUrl(reqUrl)
+  const cid = await getCidFromSubdomainUrl(reqUrl)
   const pathname = reqUrl.pathname
 
   // Validation layer - root CID

--- a/packages/edge-gateway/test/index.spec.js
+++ b/packages/edge-gateway/test/index.spec.js
@@ -1,6 +1,9 @@
 import test from 'ava'
-import { createErrorHtmlContent } from '../src/errors.js'
 
+import { base32 } from 'multiformats/bases/base32'
+import { base16 } from 'multiformats/bases/base16'
+
+import { createErrorHtmlContent } from '../src/errors.js'
 import { getMiniflare } from './utils.js'
 
 test.beforeEach((t) => {
@@ -43,4 +46,18 @@ test('Gets content with path', async (t) => {
     'https://bafybeih74zqc6kamjpruyra4e4pblnwdpickrvk4hvturisbtveghflovq.ipfs.localhost:8787/path'
   )
   t.is(await response.text(), 'Hello gateway.nft.storage resource!')
+})
+
+test('Gets content with other base encodings', async (t) => {
+  const { mf } = t.context
+
+  const cidStr = 'bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'
+  const decodedB32 = base32.decode(cidStr)
+  const encodedB16 = base16.encode(decodedB32)
+
+  const response = await mf.dispatchFetch(
+    `https://${encodedB16.toString()}.ipfs.localhost:8787`
+  )
+  await response.waitUntil()
+  t.is(await response.text(), 'Hello nft.storage! 😎')
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,7 @@ importers:
       esbuild: ^0.14.2
       execa: ^5.1.1
       git-rev-sync: ^3.0.1
+      ipfs-core-utils: ^0.15.0
       ipfs-http-client: ^55.0.0
       ipfs-utils: ^9.0.4
       itty-router: ^2.4.5
@@ -170,6 +171,7 @@ importers:
       toucan-js: ^2.5.0
       uint8arrays: ^3.0.0
     dependencies:
+      ipfs-core-utils: 0.15.1
       itty-router: 2.6.1
       multiformats: 9.6.4
       nanoid: 3.3.3
@@ -262,7 +264,6 @@ packages:
         integrity: sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==,
       }
     engines: { node: 4.x || >=6.0.0 }
-    dev: true
 
   /@ampproject/remapping/2.2.0:
     resolution:
@@ -3551,7 +3552,6 @@ packages:
       }
     dependencies:
       multiformats: 9.6.4
-    dev: true
 
   /@istanbuljs/load-nyc-config/1.1.0:
     resolution:
@@ -3632,6 +3632,40 @@ packages:
       '@jridgewell/resolve-uri': 3.0.6
       '@jridgewell/sourcemap-codec': 1.4.11
     dev: true
+
+  /@libp2p/interfaces/2.0.4:
+    resolution:
+      {
+        integrity: sha512-MfwkTFyHJtvwNxkjOjzkXyIVvKFtEW2Q3IGRJPyPQMrtB6ll0rGMTlyJ3BQS1bcD0YkNhggFm+8XiU2/0LCBhQ==,
+      }
+    engines: { node: '>=16.0.0', npm: '>=7.0.0' }
+    dependencies:
+      '@multiformats/multiaddr': 10.2.1
+      err-code: 3.0.1
+      interface-datastore: 6.1.1
+      it-pushable: 2.0.2
+      it-stream-types: 1.0.4
+      multiformats: 9.6.4
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
+  /@libp2p/logger/1.1.6:
+    resolution:
+      {
+        integrity: sha512-ZKoRUt7cyHlbxHYDZ1Fn3A+ByqGABdmd4z07+1TfVvpEQSpn2IVcV0mt6ff5kUUtGuVeSrqK1/ZDzWqhgg56vg==,
+      }
+    engines: { node: '>=16.0.0', npm: '>=7.0.0' }
+    dependencies:
+      '@libp2p/interfaces': 2.0.4
+      debug: 4.3.4
+      interface-datastore: 6.1.0
+      multiformats: 9.6.4
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
 
   /@magic-sdk/admin/1.4.0:
     resolution:
@@ -4214,6 +4248,36 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@multiformats/multiaddr-to-uri/9.0.1:
+    resolution:
+      {
+        integrity: sha512-kSyHZ2lKjoEzHu/TM4ZVwFj4AWV1B9qFBFJjYb/fK1NqrnrNb/M3uhoyckJvP7WZvpDsnEc7fUCpmPipDY6LMw==,
+      }
+    dependencies:
+      '@multiformats/multiaddr': 10.2.1
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
+  /@multiformats/multiaddr/10.2.1:
+    resolution:
+      {
+        integrity: sha512-i1l5tEmWgJ3bQYew3gL0yI5jy+8JfIpFcaBbjwbS7LyQSHYZLjDyfagFWMPEDdQB3/gxYpkddHlci4uJW/IMZw==,
+      }
+    engines: { node: '>=16.0.0', npm: '>=7.0.0' }
+    dependencies:
+      dns-over-http-resolver: 2.0.1
+      err-code: 3.0.1
+      is-ip: 4.0.0
+      multiformats: 9.6.4
+      uint8arrays: 3.0.0
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
   /@multiformats/murmur3/1.1.1:
     resolution:
       {
@@ -4496,28 +4560,24 @@ packages:
       {
         integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==,
       }
-    dev: true
 
   /@protobufjs/base64/1.1.2:
     resolution:
       {
         integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
       }
-    dev: true
 
   /@protobufjs/codegen/2.0.4:
     resolution:
       {
         integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==,
       }
-    dev: true
 
   /@protobufjs/eventemitter/1.1.0:
     resolution:
       {
         integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
       }
-    dev: true
 
   /@protobufjs/fetch/1.1.0:
     resolution:
@@ -4527,42 +4587,36 @@ packages:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.0
-    dev: true
 
   /@protobufjs/float/1.0.2:
     resolution:
       {
         integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
       }
-    dev: true
 
   /@protobufjs/inquire/1.1.0:
     resolution:
       {
         integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==,
       }
-    dev: true
 
   /@protobufjs/path/1.1.2:
     resolution:
       {
         integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==,
       }
-    dev: true
 
   /@protobufjs/pool/1.1.0:
     resolution:
       {
         integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
       }
-    dev: true
 
   /@protobufjs/utf8/1.1.0:
     resolution:
       {
         integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
       }
-    dev: true
 
   /@rollup/plugin-commonjs/21.1.0_rollup@2.70.2:
     resolution:
@@ -5133,14 +5187,12 @@ packages:
       {
         integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==,
       }
-    dev: true
 
   /@types/minimatch/3.0.5:
     resolution:
       {
         integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==,
       }
-    dev: true
 
   /@types/minimist/1.2.2:
     resolution:
@@ -5894,7 +5946,6 @@ packages:
       {
         integrity: sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==,
       }
-    dev: true
 
   /anymatch/3.1.2:
     resolution:
@@ -6373,7 +6424,6 @@ packages:
       {
         integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
       }
-    dev: true
 
   /base-x/4.0.0:
     resolution:
@@ -6460,7 +6510,6 @@ packages:
       }
     dependencies:
       browser-readablestream-to-it: 1.0.3
-    dev: true
 
   /blockstore-core/1.0.5:
     resolution:
@@ -6569,7 +6618,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    dev: true
 
   /braces/3.0.2:
     resolution:
@@ -6617,7 +6665,6 @@ packages:
       {
         integrity: sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==,
       }
-    dev: true
 
   /browser-stdout/1.3.1:
     resolution:
@@ -6692,7 +6739,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    dev: true
 
   /builtin-modules/3.2.0:
     resolution:
@@ -7369,7 +7415,6 @@ packages:
 
   /concat-map/0.0.1:
     resolution: { integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= }
-    dev: true
 
   /concat-stream/1.6.2:
     resolution:
@@ -8203,6 +8248,20 @@ packages:
       - supports-color
     dev: true
 
+  /dns-over-http-resolver/2.0.1:
+    resolution:
+      {
+        integrity: sha512-2S7WCfi3U49GSwnfGQrK1YPOXuRjtVBUELqvUld9umNOZxph6t9iUBfv56mK52D9a4Urv8M8/CrqOfOvVkWPkg==,
+      }
+    dependencies:
+      debug: 4.3.4
+      native-fetch: 4.0.2
+      receptacle: 1.3.2
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
   /dnslink-cloudflare/3.0.0:
     resolution:
       {
@@ -8395,7 +8454,6 @@ packages:
     engines: { node: '>=6' }
     dependencies:
       encoding: 0.1.13
-    dev: true
 
   /electron-to-chromium/1.4.127:
     resolution:
@@ -8443,7 +8501,6 @@ packages:
       }
     dependencies:
       iconv-lite: 0.6.3
-    dev: true
 
   /end-of-stream/1.4.4:
     resolution:
@@ -8489,7 +8546,6 @@ packages:
       {
         integrity: sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==,
       }
-    dev: true
 
   /error-ex/1.3.2:
     resolution:
@@ -10215,7 +10271,6 @@ packages:
       {
         integrity: sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g==,
       }
-    dev: true
 
   /fast-glob/3.2.11:
     resolution:
@@ -10673,7 +10728,6 @@ packages:
       {
         integrity: sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==,
       }
-    dev: true
 
   /get-own-enumerable-property-symbols/3.0.2:
     resolution:
@@ -11292,7 +11346,6 @@ packages:
     engines: { node: '>=0.10.0' }
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
   /idb-keyval/6.1.0:
     resolution:
@@ -11469,7 +11522,16 @@ packages:
       interface-store: 2.0.2
       nanoid: 3.3.3
       uint8arrays: 3.0.0
-    dev: true
+
+  /interface-datastore/6.1.1:
+    resolution:
+      {
+        integrity: sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==,
+      }
+    dependencies:
+      interface-store: 2.0.2
+      nanoid: 3.3.3
+      uint8arrays: 3.0.0
 
   /interface-store/1.0.2:
     resolution:
@@ -11483,7 +11545,6 @@ packages:
       {
         integrity: sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==,
       }
-    dev: true
 
   /internal-slot/1.0.3:
     resolution:
@@ -11520,6 +11581,14 @@ packages:
       }
     engines: { node: '>=8' }
     dev: true
+
+  /ip-regex/5.0.0:
+    resolution:
+      {
+        integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dev: false
 
   /ip/1.1.5:
     resolution: { integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo= }
@@ -11566,13 +11635,29 @@ packages:
       - supports-color
     dev: true
 
+  /ipfs-core-types/0.11.1:
+    resolution:
+      {
+        integrity: sha512-K7ZSx9EPEvT4At2kExKyMCqY4Jo3Nb/VnC/iSWqFKRaqb0MTB4IJgvWrwwDuN541tn+dvUnTfOp2wWQSov1UAw==,
+      }
+    dependencies:
+      '@ipld/dag-pb': 2.1.16
+      '@multiformats/multiaddr': 10.2.1
+      interface-datastore: 6.1.1
+      ipfs-unixfs: 6.0.9
+      multiformats: 9.6.4
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
   /ipfs-core-types/0.8.4:
     resolution:
       {
         integrity: sha512-sbRZA1QX3xJ6ywTiVQZMOxhlhp4osAZX2SXx3azOLxAtxmGWDMkHYt722VV4nZ2GyJy8qyk5GHQIZ0uvQnpaTg==,
       }
     dependencies:
-      interface-datastore: 6.1.0
+      interface-datastore: 6.1.1
       multiaddr: 10.0.1
       multiformats: 9.6.4
     transitivePeerDependencies:
@@ -11606,7 +11691,7 @@ packages:
       debug: 4.3.4
       err-code: 3.0.1
       ipfs-core-types: 0.8.4
-      ipfs-unixfs: 6.0.7
+      ipfs-unixfs: 6.0.9
       ipfs-utils: 9.0.6
       it-all: 1.0.6
       it-map: 1.0.6
@@ -11656,6 +11741,37 @@ packages:
       - supports-color
     dev: true
 
+  /ipfs-core-utils/0.15.1:
+    resolution:
+      {
+        integrity: sha512-nZmUiLctJWMFrEciVkKdDUO2xLpXWy7Ilt0VMJ35Y5+OJznCXxMHUQo1WUALATlo9ziHgDdHFrAUuyW0yB2rww==,
+      }
+    dependencies:
+      '@libp2p/logger': 1.1.6
+      '@multiformats/multiaddr': 10.2.1
+      '@multiformats/multiaddr-to-uri': 9.0.1
+      any-signal: 3.0.1
+      blob-to-it: 1.0.4
+      browser-readablestream-to-it: 1.0.3
+      err-code: 3.0.1
+      ipfs-core-types: 0.11.1
+      ipfs-unixfs: 6.0.9
+      ipfs-utils: 9.0.6
+      it-all: 1.0.6
+      it-map: 1.0.6
+      it-peekable: 1.0.3
+      it-to-stream: 1.0.0
+      merge-options: 3.0.4
+      multiformats: 9.6.4
+      nanoid: 3.3.3
+      parse-duration: 1.0.2
+      timeout-abort-controller: 3.0.0
+      uint8arrays: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - undici
+    dev: false
+
   /ipfs-http-client/55.0.0:
     resolution:
       {
@@ -11700,7 +11816,7 @@ packages:
       err-code: 3.0.1
       hamt-sharding: 2.0.1
       interface-blockstore: 1.0.2
-      ipfs-unixfs: 6.0.7
+      ipfs-unixfs: 6.0.9
       it-last: 1.0.6
       multiformats: 9.6.4
       uint8arrays: 3.0.0
@@ -11719,7 +11835,7 @@ packages:
       err-code: 3.0.1
       hamt-sharding: 2.0.1
       interface-blockstore: 1.0.2
-      ipfs-unixfs: 6.0.7
+      ipfs-unixfs: 6.0.9
       it-all: 1.0.6
       it-batch: 1.0.9
       it-first: 1.0.7
@@ -11744,6 +11860,16 @@ packages:
       protobufjs: 6.11.2
     dev: true
 
+  /ipfs-unixfs/6.0.9:
+    resolution:
+      {
+        integrity: sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==,
+      }
+    engines: { node: '>=16.0.0', npm: '>=7.0.0' }
+    dependencies:
+      err-code: 3.0.1
+      protobufjs: 6.11.2
+
   /ipfs-utils/9.0.6:
     resolution:
       {
@@ -11764,7 +11890,6 @@ packages:
       node-fetch: /@achingbrain/node-fetch/2.6.7
       react-native-fetch-api: 2.0.0
       stream-to-it: 0.2.4
-    dev: true
 
   /irregular-plurals/3.3.0:
     resolution:
@@ -11910,7 +12035,6 @@ packages:
       {
         integrity: sha512-r8EEQQsqT+Gn0aXFx7lTFygYQhILLCB+wn0WCDL5LZRINeLH/Rvw1j2oKodELLXYNImQ3CRlVsY8wW4cGOsyuw==,
       }
-    dev: true
 
   /is-error/2.2.2:
     resolution:
@@ -12009,6 +12133,16 @@ packages:
     dependencies:
       ip-regex: 4.3.0
     dev: true
+
+  /is-ip/4.0.0:
+    resolution:
+      {
+        integrity: sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      ip-regex: 5.0.0
+    dev: false
 
   /is-map/2.0.2:
     resolution:
@@ -12114,7 +12248,6 @@ packages:
         integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==,
       }
     engines: { node: '>=8' }
-    dev: true
 
   /is-plain-object/5.0.0:
     resolution:
@@ -12314,7 +12447,6 @@ packages:
         integrity: sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==,
       }
     engines: { node: '>=12' }
-    dev: true
 
   /isstream/0.1.2:
     resolution: { integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo= }
@@ -12411,7 +12543,6 @@ packages:
       {
         integrity: sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==,
       }
-    dev: true
 
   /it-batch/1.0.9:
     resolution:
@@ -12449,7 +12580,6 @@ packages:
     dependencies:
       '@types/minimatch': 3.0.5
       minimatch: 3.1.2
-    dev: true
 
   /it-last/1.0.6:
     resolution:
@@ -12463,7 +12593,6 @@ packages:
       {
         integrity: sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==,
       }
-    dev: true
 
   /it-parallel-batch/1.0.10:
     resolution:
@@ -12479,7 +12608,6 @@ packages:
       {
         integrity: sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ==,
       }
-    dev: true
 
   /it-pipe/1.1.0:
     resolution:
@@ -12487,6 +12615,20 @@ packages:
         integrity: sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg==,
       }
     dev: true
+
+  /it-pushable/2.0.2:
+    resolution:
+      {
+        integrity: sha512-f/n6HqXGDbHvuMR/3UN+S6W4y/bS1Pxg6Lb0oVc5dbflxy5f3NKkizKs86B8vzqHnB9hm1YpE0pgcEvI3FKDQw==,
+      }
+    dev: false
+
+  /it-stream-types/1.0.4:
+    resolution:
+      {
+        integrity: sha512-0F3CqTIcIHwtnmIgqd03a7sw8BegAmE32N2w7anIGdALea4oAN4ltqPgDMZ7zn4XPLZifXEZlBXSzgg64L1Ebw==,
+      }
+    dev: false
 
   /it-take/1.0.2:
     resolution:
@@ -12507,7 +12649,6 @@ packages:
       p-defer: 3.0.0
       p-fifo: 1.0.0
       readable-stream: 3.6.0
-    dev: true
 
   /itty-router/2.6.1:
     resolution:
@@ -13229,7 +13370,6 @@ packages:
       {
         integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==,
       }
-    dev: true
 
   /loose-envify/1.4.0:
     resolution:
@@ -13440,7 +13580,6 @@ packages:
     engines: { node: '>=10' }
     dependencies:
       is-plain-obj: 2.1.0
-    dev: true
 
   /merge-stream/2.0.0:
     resolution:
@@ -13703,7 +13842,6 @@ packages:
       }
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
 
   /minimatch/4.2.1:
     resolution:
@@ -13989,7 +14127,15 @@ packages:
       node-fetch: '*'
     dependencies:
       node-fetch: /@achingbrain/node-fetch/2.6.7
-    dev: true
+
+  /native-fetch/4.0.2:
+    resolution:
+      {
+        integrity: sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==,
+      }
+    peerDependencies:
+      undici: '*'
+    dev: false
 
   /natural-compare/1.4.0:
     resolution: { integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc= }
@@ -14583,7 +14729,6 @@ packages:
         integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==,
       }
     engines: { node: '>=8' }
-    dev: true
 
   /p-event/4.2.0:
     resolution:
@@ -14603,7 +14748,6 @@ packages:
     dependencies:
       fast-fifo: 1.1.0
       p-defer: 3.0.0
-    dev: true
 
   /p-filter/3.0.0:
     resolution:
@@ -14890,7 +15034,6 @@ packages:
       {
         integrity: sha512-Dg27N6mfok+ow1a2rj/nRjtCfaKrHUZV2SJpEn/s8GaVUSlf4GGRCRP1c13Hj+wfPKVMrFDqLMLITkYKgKxyyg==,
       }
-    dev: true
 
   /parse-entities/2.0.0:
     resolution:
@@ -15652,7 +15795,6 @@ packages:
       '@types/long': 4.0.2
       '@types/node': 17.0.30
       long: 4.0.0
-    dev: true
 
   /proxy-addr/2.0.7:
     resolution:
@@ -15951,7 +16093,6 @@ packages:
       }
     dependencies:
       p-defer: 3.0.0
-    dev: true
 
   /react-redux/7.2.8_ef5jwxihqo6n7gxfmzogljlgcm:
     resolution:
@@ -16088,7 +16229,6 @@ packages:
       }
     dependencies:
       ms: 2.1.3
-    dev: true
 
   /rechoir/0.6.2:
     resolution: { integrity: sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q= }
@@ -16491,7 +16631,6 @@ packages:
       {
         integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==,
       }
-    dev: true
 
   /retry/0.12.0:
     resolution: { integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs= }
@@ -17376,7 +17515,6 @@ packages:
       }
     dependencies:
       get-iterator: 1.0.2
-    dev: true
 
   /streaming-iterables/6.2.0:
     resolution:
@@ -18037,6 +18175,15 @@ packages:
       retimer: 3.0.0
     dev: true
 
+  /timeout-abort-controller/3.0.0:
+    resolution:
+      {
+        integrity: sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==,
+      }
+    dependencies:
+      retimer: 3.0.0
+    dev: false
+
   /timer2/1.0.0:
     resolution:
       {
@@ -18686,7 +18833,6 @@ packages:
       {
         integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==,
       }
-    dev: true
 
   /varname/2.0.3:
     resolution: { integrity: sha1-BejcZPu25ZFw3kSq1N3quKuHto4= }


### PR DESCRIPTION
This PR adds support for gateway to try to resolve CIDs encoded into more bases than b32 and b58. It includes all the basic bases exported by multiformats module.

`ipfs-core-utils` was added to have a quick way of getting what base decoder we want to try.

Closes https://github.com/nftstorage/nftstorage.link/issues/111