### PR TITLE
fix: cache match by request only

### DIFF
--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -274,7 +274,6 @@ async function cdnResolution(request, env, cache) {
     const res = await pAny(
       [
         cache.match(request), // Request from cache API
-        cache.match(request.url), // Request URL from cache API - To be deprecated
         getFromPermaCache(request, env),
       ],
       {


### PR DESCRIPTION
In https://github.com/nftstorage/nftstorage.link/pull/141#pullrequestreview-1024989108 we added cache match by request to support range header caching. For a couple of days, we kept running the match by URL to still rely on the caching LRU items. Now the LRU should have been rotated and we can move into request only