### PR TITLE
feat: superhot support for w3s.link read

### DIFF
--- a/packages/api/src/env.js
+++ b/packages/api/src/env.js
@@ -8,7 +8,7 @@ import { DBClient } from './utils/db-client.js'
 /**
  * @typedef {Object} EnvInput
  * @property {string} ENV
- * @property {string} GATEWAY_DOMAIN
+ * @property {string[]} GATEWAY_DOMAINS
  * @property {string} NFT_STORAGE_API
  * @property {string} DATABASE_URL
  * @property {string} DATABASE_TOKEN

--- a/packages/api/src/utils/url.js
+++ b/packages/api/src/utils/url.js
@@ -34,7 +34,7 @@ export function getSourceUrl(request, env) {
       .length
   ) {
     throw new InvalidUrlError(
-      `invalid URL provided: ${urlString}: not nftstorage.link or w3s.link URL`
+      `invalid URL provided: ${urlString}: not ${env.GATEWAY_DOMAINS.join(' or ')} URL`
     )
   }
 

--- a/packages/api/src/utils/url.js
+++ b/packages/api/src/utils/url.js
@@ -4,6 +4,10 @@ import { InvalidUrlError } from '../errors.js'
 import { normalizeCid } from './cid.js'
 
 /**
+ * @typedef {import('../env').Env} Env
+ */
+
+/**
  * Parses provided URL and verifes if is a valid nftstorage.link URL
  *
  * @param {Request} request
@@ -25,9 +29,12 @@ export function getSourceUrl(request, env) {
       `invalid URL provided: ${request.params.url}: maximum allowed length or URL is ${MAX_ALLOWED_URL_LENGTH}`
     )
   }
-  if (!urlString.includes(env.GATEWAY_DOMAIN)) {
+  if (
+    !env.GATEWAY_DOMAINS.filter((gwDomain) => urlString.includes(gwDomain))
+      .length
+  ) {
     throw new InvalidUrlError(
-      `invalid URL provided: ${urlString}: not nftstorage.link URL`
+      `invalid URL provided: ${urlString}: not nftstorage.link or w3s.link URL`
     )
   }
 
@@ -54,8 +61,9 @@ export function getNormalizedUrl(candidateUrl, env) {
       ? `?${queryParamsCandidate}`
       : ''
 
+    // Always set normalized url as first URL in supported gateway domains (w3s.link)
     return new URL(
-      `${candidateUrl.protocol}//${cid}.ipfs.${env.GATEWAY_DOMAIN}${path}${queryParams}`
+      `${candidateUrl.protocol}//${cid}.ipfs.${env.GATEWAY_DOMAINS[0]}${path}${queryParams}`
     )
   }
 

--- a/packages/api/test/perma-cache-get.spec.js
+++ b/packages/api/test/perma-cache-get.spec.js
@@ -88,3 +88,27 @@ test('Gets 404 response from perma cache by URL when url not perma cached', asyn
   )
   t.is(responseGet.status, 404)
 })
+
+test('Gets 400 response from perma cache by URL when url not valid', async (t) => {
+  const { mf } = t.context
+  const url =
+    'http://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:9083/'
+
+  // GET URL content from perma cache
+  const responseGet = await mf.dispatchFetch(getPermaCachePutUrl(url), {
+    method: 'GET',
+  })
+  t.is(responseGet.status, 400)
+})
+
+test('Gets 404 response from perma cache by URL when url from secondary supported gateway not perma cached', async (t) => {
+  const { mf } = t.context
+  const url =
+    'http://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:9082/'
+
+  // GET URL content from perma cache
+  const responseGet = await mf.dispatchFetch(getPermaCachePutUrl(url), {
+    method: 'GET',
+  })
+  t.is(responseGet.status, 404)
+})

--- a/packages/api/test/perma-cache-post.spec.js
+++ b/packages/api/test/perma-cache-post.spec.js
@@ -31,7 +31,7 @@ test('Fails when invalid url is provided', async (t) => {
   t.is(body, 'invalid URL provided: test.png: Invalid URL')
 })
 
-test('Fails when non nftstorage.link url is provided', async (t) => {
+test('Fails when non nftstorage.link or w3s.link url is provided', async (t) => {
   const { mf, user } = t.context
 
   const response = await mf.dispatchFetch(
@@ -46,7 +46,7 @@ test('Fails when non nftstorage.link url is provided', async (t) => {
   const body = await response.json()
   t.is(
     body,
-    'invalid URL provided: https://example.com/test.png: not nftstorage.link URL'
+    'invalid URL provided: https://example.com/test.png: not nftstorage.link or w3s.link URL'
   )
 })
 

--- a/packages/api/test/perma-cache-post.spec.js
+++ b/packages/api/test/perma-cache-post.spec.js
@@ -31,7 +31,7 @@ test('Fails when invalid url is provided', async (t) => {
   t.is(body, 'invalid URL provided: test.png: Invalid URL')
 })
 
-test('Fails when non nftstorage.link or w3s.link url is provided', async (t) => {
+test('Fails when non localhost:9081 or localhost:9082 url is provided', async (t) => {
   const { mf, user } = t.context
 
   const response = await mf.dispatchFetch(
@@ -46,7 +46,7 @@ test('Fails when non nftstorage.link or w3s.link url is provided', async (t) => 
   const body = await response.json()
   t.is(
     body,
-    'invalid URL provided: https://example.com/test.png: not nftstorage.link or w3s.link URL'
+    'invalid URL provided: https://example.com/test.png: not localhost:9081 or localhost:9082 URL'
   )
 })
 

--- a/packages/api/test/scripts/worker-globals.js
+++ b/packages/api/test/scripts/worker-globals.js
@@ -3,5 +3,5 @@ export const globals = {
   NFT_STORAGE_API: 'http://localhost:9096',
   DATABASE_TOKEN:
     'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJyb2xlIjoic2VydmljZV9yb2xlIn0.necIJaiP7X2T2QjGeV-FhpkizcNTX8HjDDBAxpgQTEI',
-  GATEWAY_DOMAIN: 'localhost:9081',
+  GATEWAY_DOMAINS: ['localhost:9081', 'localhost:9082'],
 }

--- a/packages/api/test/utils.js
+++ b/packages/api/test/utils.js
@@ -17,7 +17,7 @@ export function getParsedUrl(url) {
     const queryParams = queryParamsString.length ? `?${queryParamsString}` : ''
 
     normalizedUrl = new URL(
-      `${normalizedUrl.protocol}//${cid}.ipfs.${globals.GATEWAY_DOMAIN}${path}${queryParams}`
+      `${normalizedUrl.protocol}//${cid}.ipfs.${globals.GATEWAY_DOMAINS[0]}${path}${queryParams}`
     )
   }
 

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -20,7 +20,7 @@ DATABASE_URL = "https://nft-link-prod.herokuapp.com"
 NFT_STORAGE_API = "https://api.nft.storage"
 DEBUG = "false"
 ENV = "production"
-GATEWAY_DOMAIN = "nftstorage.link"
+GATEWAY_DOMAINS = "[\"w3s.link\", \"nftstorage.link\"]"
 
 [[env.production.r2_buckets]]
 bucket_name = "super-hot"
@@ -46,7 +46,7 @@ DATABASE_URL = "https://nft-link-staging.herokuapp.com"
 NFT_STORAGE_API = "https://api-staging.nft.storage"
 DEBUG = "true"
 ENV = "staging"
-GATEWAY_DOMAIN = "nftstorage.link"
+GATEWAY_DOMAINS = "[\"w3s.link\", \"nftstorage.link\"]"
 
 [[env.staging.r2_buckets]]
 bucket_name = "super-hot-staging"
@@ -65,7 +65,7 @@ workers_dev = true
 [env.test.vars]
 DEBUG = "true"
 ENV = "test"
-GATEWAY_DOMAIN = "localhost:9081"
+GATEWAY_DOMAINS = "[\"localhost:9081\", \"localhost:9082\"]"
 
 # Dev!
 [env.vsantos]
@@ -75,4 +75,4 @@ account_id = "7ec0b7cf2ec201b2580374e53ba5f37b"
 [env.vsantos.vars]
 DEBUG = "true"
 ENV = "test"
-GATEWAY_DOMAIN = "nftstorage.link"
+GATEWAY_DOMAINS = "[\"w3s.link\", \"nftstorage.link\"]"


### PR DESCRIPTION
This PR adds support for superhot reads in w3s.link - we still need to look into moving this API into a common context instead of tied with nftstorage.link (not included in current initiative scope)

w3s.link should be able to read from SuperHot perma-cache and also share same content in R2 regardless of domain used for perma-cache. It currently gets 400 error due to not being a valid domain to get. This PR changes that by allowing reads from either nftstorage.link or w3s.link (array in ENV variable). 

Moreover, I took decision here to modify normalized URLs to just be w3s.link all the time (converted from nftstorage.link when those are provided). Main reason for this is our current direction of Web3.storage platform and nft.storage being part of the stack.