### PR TITLE
feat: add content security policy header

### DIFF
--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -537,7 +537,7 @@ function getTransformedResponseWithCustomHeaders(response) {
 
   clonedResponse.headers.set(
     'content-security-policy',
-    "connect-src 'self'; script-src 'self'"
+    "default-src 'self' 'unsafe-inline' blob: data: ; form-action 'self' ; navigate-to 'self' "
   )
 
   return clonedResponse

--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -117,7 +117,7 @@ export async function gatewayIpfs(request, env, ctx, options = {}) {
     const responseTime = Date.now() - startTs
 
     options.onCdnResolution && options.onCdnResolution(res, responseTime)
-    return res
+    return getTransformedResponseWithCustomHeaders(res)
   } else if (
     (request.headers.get('Cache-Control') || '').includes('only-if-cached')
   ) {
@@ -152,28 +152,22 @@ export async function gatewayIpfs(request, env, ctx, options = {}) {
 
     options.onRaceResolution &&
       options.onRaceResolution(winnerGwResponse, gatewayReqs, cid)
-
-    // Add response header
-    const raceResponse = getTransformedResponseWithCustomHeaders(
-      winnerGwResponse.response
-    )
-
     // Cache response
     ctx.waitUntil(
       (async () => {
         const contentLengthMb = Number(
-          raceResponse.headers.get('content-length')
+          winnerGwResponse.response.headers.get('content-length')
         )
 
         // Cache request in Cloudflare CDN if smaller than CF_CACHE_MAX_OBJECT_SIZE
         if (contentLengthMb <= CF_CACHE_MAX_OBJECT_SIZE) {
-          await cache.put(request, raceResponse.clone())
+          await cache.put(request, winnerGwResponse.response.clone())
         }
       })()
     )
 
     // forward winner gateway response
-    return raceResponse
+    return getTransformedResponseWithCustomHeaders(winnerGwResponse.response)
   } catch (err) {
     const responses = await pSettle(gatewayReqs)
 
@@ -539,9 +533,7 @@ function getDurableRequestUrl(request, route, data) {
  * @param {Response} response
  */
 function getTransformedResponseWithCustomHeaders(response) {
-  const clonedResponse = new Response(response.body, {
-    headers: response.headers,
-  })
+  const clonedResponse = new Response(response.body, response)
 
   clonedResponse.headers.set(
     'content-security-policy',


### PR DESCRIPTION
Based on proposal from @Gozala https://gozala.io/workspace/#/page/ipfs%20content-security-policy let's add Content-Security-Policy header to only allow requests within same origin.

This is added to the response from the gateway race before it is cached, so that responses from cache will also have the header already set.