### PR TITLE
feat: add bindings services to edge gateway

### DIFF
--- a/packages/edge-gateway/wrangler.toml
+++ b/packages/edge-gateway/wrangler.toml
@@ -32,6 +32,12 @@ GATEWAY_HOSTNAME = 'ipfs.nftstorage.link'
 DEBUG = "false"
 ENV = "production"
 
+[[env.production.services]]
+binding = "EDGE_GATEWAY"
+type = "service"
+service = "dotstorage-edge-gateway-production"
+environment = "production"
+
 # Staging!
 [env.staging]
 # name = "gateway-nft-storage-staging"
@@ -48,6 +54,12 @@ routes = [
 GATEWAY_HOSTNAME = 'ipfs-staging.nftstorage.link'
 DEBUG = "true"
 ENV = "staging"
+
+[[env.staging.services]]
+binding = "EDGE_GATEWAY"
+type = "service"
+service = "dotstorage-edge-gateway-staging"
+environment = "production"
 
 # Test!
 [env.test]


### PR DESCRIPTION
Adds bindings to use edge gateway from dotstorage reads pipeline 

follow up from https://github.com/nftstorage/nftstorage.link/pull/174