### PR TITLE
fix: ipfs path resolution with 301 status

### DIFF
--- a/packages/edge-gateway/src/ipfs.js
+++ b/packages/edge-gateway/src/ipfs.js
@@ -30,7 +30,7 @@ export async function ipfsGet(request, env) {
     `https://${nCid}.${env.IPFS_GATEWAY_HOSTNAME}${redirectPath}${redirectQueryString}`
   )
 
-  return Response.redirect(url.toString(), 302)
+  return Response.redirect(url.toString(), 301)
 }
 
 /**

--- a/packages/edge-gateway/test/ipfs-path.spec.js
+++ b/packages/edge-gateway/test/ipfs-path.spec.js
@@ -30,7 +30,7 @@ test('should resolve a cid v0 with IPFS canonical resolution', async (t) => {
     'https://localhost:8787/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
   )
   await response.waitUntil()
-  t.is(response.status, 302)
+  t.is(response.status, 301)
   t.is(
     response.headers.get('location'),
     'https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.localhost:8787/'
@@ -44,7 +44,7 @@ test('should resolve a cid v1 with IPFS canonical resolution', async (t) => {
     'https://localhost:8787/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'
   )
   await response.waitUntil()
-  t.is(response.status, 302)
+  t.is(response.status, 301)
   t.is(
     response.headers.get('location'),
     'https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:8787/'
@@ -58,7 +58,7 @@ test('should resolve a cid and path with IPFS canonical resolution', async (t) =
     'https://localhost:8787/ipfs/bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu/path/file.txt'
   )
   await response.waitUntil()
-  t.is(response.status, 302)
+  t.is(response.status, 301)
   t.is(
     response.headers.get('location'),
     'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.localhost:8787/path/file.txt'
@@ -72,7 +72,7 @@ test('should resolve a cid and path with IPFS canonical resolution when subdomai
     'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.localhost:8787/ipfs/bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu/path/file.txt'
   )
   await response.waitUntil()
-  t.is(response.status, 302)
+  t.is(response.status, 301)
   t.is(
     response.headers.get('location'),
     'https://bafybeifvsmjgbhck72pabliifeo35cew5yhxujfqjxg4g32vr3yv24h6zu.ipfs.localhost:8787/path/file.txt'
@@ -87,7 +87,7 @@ test('should resolve a cid IPFS canonical resolution keeping query parameters', 
     `https://localhost:8787/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq${queryString}`
   )
   await response.waitUntil()
-  t.is(response.status, 302)
+  t.is(response.status, 301)
   t.is(
     response.headers.get('location'),
     `https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:8787/${queryString}`
@@ -101,7 +101,7 @@ test('should resolve a cid IPFS canonical resolution with same path as IPFS path
     'https://localhost:8787/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'
   )
   await response.waitUntil()
-  t.is(response.status, 302)
+  t.is(response.status, 301)
   t.is(
     response.headers.get('location'),
     'https://bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq.ipfs.localhost:8787/ipfs/bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupoq'


### PR DESCRIPTION
This PR moves status code of path resolution redirect from 302 to 301. This aligns with other gateways do like dweb.link and flags to clients a permanent redirection. 

This should help with browser local caching related to https://github.com/web3-storage/reads/issues/81