### PR TITLE
fix: csp headers connect self with blob and data support

### DIFF
--- a/packages/edge-gateway/src/gateway.js
+++ b/packages/edge-gateway/src/gateway.js
@@ -57,7 +57,7 @@ function getTransformedResponseWithCspHeaders(response) {
 
   clonedResponse.headers.set(
     'content-security-policy',
-    "default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://*.githubusercontent.com; form-action 'self' ; navigate-to 'self'; connect-src 'self' https://polygon-rpc.com https://rpc.testnet.fantom.network "
+    "default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://*.githubusercontent.com; form-action 'self' ; navigate-to 'self'; connect-src 'self' blob: data: https://polygon-rpc.com https://rpc.testnet.fantom.network "
   )
 
   return clonedResponse


### PR DESCRIPTION
This PR adds `blob:` and `data:` support for connect self in csp headers set for response

Context: https://github.com/nftstorage/nftstorage.link/issues/175#issuecomment-1304916390