### PR TITLE
feat: remove loki logging from edge-gateway

### DIFF
--- a/packages/edge-gateway/src/bindings.d.ts
+++ b/packages/edge-gateway/src/bindings.d.ts
@@ -1,5 +1,4 @@
 import Toucan from 'toucan-js'
-import { Logging } from '@web3-storage/worker-utils/loki'
 
 export {}
 
@@ -23,7 +22,6 @@ export interface EnvTransformed {
   IPFS_GATEWAY_HOSTNAME: string
   IPNS_GATEWAY_HOSTNAME: string
   sentry?: Toucan
-  log: Logging
   startTime: number
 }
 

--- a/packages/edge-gateway/src/env.js
+++ b/packages/edge-gateway/src/env.js
@@ -1,7 +1,6 @@
 /* global BRANCH, VERSION, COMMITHASH, SENTRY_RELEASE */
 
 import Toucan from 'toucan-js'
-import { Logging } from '@web3-storage/worker-utils/loki'
 import pkg from '../package.json'
 
 /**
@@ -25,21 +24,6 @@ export function envAll(request, env, ctx) {
   env.SENTRY_RELEASE = SENTRY_RELEASE
 
   env.sentry = getSentry(request, env, ctx)
-
-  env.log = new Logging(request, ctx, {
-    // @ts-ignore TODO: url should be optional together with token
-    url: env.LOKI_URL,
-    token: env.LOKI_TOKEN,
-    debug: Boolean(env.DEBUG),
-    version: env.VERSION,
-    commit: env.COMMITHASH,
-    branch: env.BRANCH,
-    worker: 'nftstorage.link',
-    env: env.ENV,
-    sentry: env.sentry,
-  })
-
-  env.log.time('request')
 }
 
 /**

--- a/packages/edge-gateway/src/error-handler.js
+++ b/packages/edge-gateway/src/error-handler.js
@@ -9,10 +9,6 @@ export function errorHandler(err, env) {
 
   const status = err.status || 500
 
-  if (env.sentry && status >= 500) {
-    env.log.error(err)
-  }
-
   return new Response(err.message || 'Server Error', {
     status,
     headers: {

--- a/packages/edge-gateway/src/index.js
+++ b/packages/edge-gateway/src/index.js
@@ -46,14 +46,8 @@ export default {
    */
   async fetch(request, env, ctx) {
     try {
-      const res = await router.handle(request, env, ctx)
-      env.log.timeEnd('request')
-      return env.log.end(res)
+      return await router.handle(request, env, ctx)
     } catch (/** @type {any} */ error) {
-      if (env.log) {
-        env.log.timeEnd('request')
-        return env.log.end(serverError(error, request, env))
-      }
       return serverError(error, request, env)
     }
   },


### PR DESCRIPTION
logging to Loki is costing thousands of dollars every month, and is unecessary since logs from this service are captured by Cloudflare's Logpush anyway