### PR TITLE
feat: introduce release-please manifest for edge-gateway

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,0 +1,12 @@
+{
+  "release-type": "node",
+  "separate-pull-requests": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix", "section": "Fixes", "hidden": false },
+    { "type": "chore", "section": "Other Changes", "hidden": false }
+  ],
+  "packages": {
+    "packages/edge-gateway": {}
+  }
+}

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "packages/edge-gateway": "1.15.2"
+}

--- a/packages/edge-gateway/README.md
+++ b/packages/edge-gateway/README.md
@@ -15,8 +15,6 @@ One time set up of your cloudflare worker subdomain for dev:
 
   ```sh
     wrangler secret put SENTRY_DSN --env $(whoami) # Get from Sentry
-    wrangler secret put LOKI_URL --env $(whoami) # Get from Loki
-    wrangler secret put LOKI_TOKEN --env $(whoami) # Get from Loki
   ```
 
 ## High level architecture


### PR DESCRIPTION
Since we upgraded to the latest release-please for edge-gateway, we need to add a manifest and config file for them.

Adapt the config and manifest from `reads`: https://github.com/storacha/reads/tree/main/.github